### PR TITLE
Fix My Team and Data Analysis page access by adding missing imports

### DIFF
--- a/frontend/src/render.js
+++ b/frontend/src/render.js
@@ -28,7 +28,9 @@ import {
     calculatePPM,
     sortPlayers,
     filterByPosition,
-    escapeHtml
+    escapeHtml,
+    calculateMinutesPercentage,
+    getFormTrend
 } from './utils.js';
 
 import {


### PR DESCRIPTION
Added missing utility function imports to render.js:
- calculateMinutesPercentage: Used 5 times across My Team and Data Analysis pages
- getFormTrend: Used in My Team page for form trend display

These functions were being called but not imported, causing runtime errors
that prevented both pages from loading properly.