### PR TITLE
Fix game week detection to use latest finished GW

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -25,7 +25,7 @@ const CACHE_BACKUP_PATH = path.join(__dirname, 'cache-backup.json');
 // FPL API Endpoints
 const FPL_BASE_URL = 'https://fantasy.premierleague.com/api';
 // GitHub CSV Base URL (FPL-Elo-Insights)
-const GITHUB_BASE_URL = 'https://raw.githubusercontent.com/ncklr/FPL-Elo-Insights/main/data/2024-25';
+const GITHUB_BASE_URL = 'https://raw.githubusercontent.com/olbauday/FPL-Elo-Insights/main/data/2025-2026';
 
 /**
  * Get GitHub CSV URLs for current context
@@ -252,12 +252,16 @@ async function fetchGithubCSV() {
     if (!cache.bootstrap.data) {
       await fetchBootstrap();
     }
-    
-    const currentEvent = cache.bootstrap.data.events.find(e => e.is_current);
-    const currentGW = currentEvent ? currentEvent.id : 11;
-    const isFinished = currentEvent ? currentEvent.finished : false;
-    
-    console.log(`📊 Current GW: ${currentGW}, Finished: ${isFinished}`);
+
+    // Find the latest FINISHED game week (not is_current which could be in-progress)
+    const finishedEvents = cache.bootstrap.data.events.filter(e => e.finished);
+    const latestFinishedGW = finishedEvents.length > 0
+      ? Math.max(...finishedEvents.map(e => e.id))
+      : 1;
+    const currentGW = latestFinishedGW;
+    const isFinished = true; // By definition, we're using a finished GW
+
+    console.log(`📊 Latest Finished GW: ${currentGW}`);
     
     const urls = getGithubUrls(currentGW, isFinished);
     

--- a/frontend/src/data.js
+++ b/frontend/src/data.js
@@ -88,19 +88,16 @@ function detectCurrentGW() {
         currentGW = 1;
         return;
     }
-    
-    const currentEvent = fplBootstrap.events.find(e => e.is_current);
-    const nextEvent = fplBootstrap.events.find(e => e.is_next);
-    
-    if (currentEvent) {
-        currentGW = currentEvent.id;
-    } else if (nextEvent) {
-        currentGW = nextEvent.id - 1;
-    } else {
-        currentGW = 1;
-    }
-    
-    console.log(`📅 Current GW detected: ${currentGW}`);
+
+    // Find the latest FINISHED game week (not is_current which could be in-progress)
+    const finishedEvents = fplBootstrap.events.filter(e => e.finished);
+    const latestFinishedGW = finishedEvents.length > 0
+        ? Math.max(...finishedEvents.map(e => e.id))
+        : 1;
+
+    currentGW = latestFinishedGW;
+
+    console.log(`📅 Latest Finished GW detected: ${currentGW}`);
 }
 
 /**


### PR DESCRIPTION
- Updated GitHub base URL to use olbauday repo and 2025-2026 season
- Changed backend GW detection to find latest FINISHED game week instead of is_current
- Changed frontend GW detection to use same logic (latest finished GW)
- This ensures My Team page shows results for the most recent completed game week
- Transfer stats now correctly use GW+1 data from GitHub

Previously, the code used is_current which could point to an in-progress GW, causing confusion. Now it always uses the latest completed GW as the reference point.