### PR TITLE
feat: add Team Builder feature for multi-gameweek transfer planning

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -28,7 +28,7 @@ let myTeamData = null;
 
 /**
  * Navigate to a specific page
- * @param {string} page - Page name ('my-team', 'transfer-committee', 'data-analysis', 'search')
+ * @param {string} page - Page name ('my-team', 'team-builder', 'data-analysis', 'charts', 'search')
  * @param {string} subTab - Optional sub-tab for pages with tabs
  */
 export function navigate(page, subTab = 'overview') {
@@ -83,6 +83,9 @@ function renderPage() {
         case 'my-team':
             renderMyTeamPage();
             break;
+        case 'team-builder':
+            renderTeamBuilderPage();
+            break;
         case 'data-analysis':
             renderDataAnalysis();
             break;
@@ -104,6 +107,11 @@ function renderPage() {
 async function renderMyTeamPage() {
     const { renderMyTeamForm } = await import('./renderMyTeam.js');
     renderMyTeamForm();
+}
+
+async function renderTeamBuilderPage() {
+    const { renderTeamBuilder } = await import('./renderTeamBuilder.js');
+    renderTeamBuilder();
 }
 
 async function renderDataAnalysis() {
@@ -334,6 +342,7 @@ function setupNavigation() {
     
     const pages = [
         { id: 'my-team', label: 'My Team', icon: 'fa-users' },
+        { id: 'team-builder', label: 'Team Builder', icon: 'fa-chess' },
         { id: 'data-analysis', label: 'Data Analysis', icon: 'fa-chart-bar' },
         { id: 'charts', label: 'Charts', icon: 'fa-chart-line' },
         { id: 'search', label: 'Search', icon: 'fa-search' }

--- a/frontend/src/renderTeamBuilder.js
+++ b/frontend/src/renderTeamBuilder.js
@@ -1,0 +1,1494 @@
+// ============================================================================
+// TEAM BUILDER PAGE MODULE
+// Multi-gameweek transfer planner with validation and auto-suggestions
+// ============================================================================
+
+import { loadMyTeam, getPlayerById, getAllPlayers, currentGW } from './data.js';
+import {
+    getPositionShort,
+    getPositionType,
+    formatCurrency,
+    formatDecimal,
+    escapeHtml,
+    calculatePPM,
+    getTeamShortName,
+    getDifficultyClass
+} from './utils.js';
+import { getFixtures } from './fixtures.js';
+import { analyzePlayerRisks, hasHighRisk, renderRiskTooltip } from './risk.js';
+import { attachRiskTooltipListeners } from './renderHelpers.js';
+import {
+    createNewPlan,
+    calculateProjectedSquad,
+    addTransfer,
+    removeTransfer,
+    validateSquad,
+    setChip,
+    findSuggestedTransfers,
+    savePlansToStorage,
+    loadPlansFromStorage,
+    deletePlanFromStorage,
+    getAvailableChips
+} from './teamBuilderHelpers.js';
+
+// ============================================================================
+// STATE
+// ============================================================================
+
+let currentTeamData = null;
+let allPlans = [];
+let activePlanId = null;
+let activeGameweek = null;
+let planningHorizon = 3; // Default 3 GWs
+let playerSearchModal = null;
+let transferOutPlayerId = null; // For player selection modal
+
+// ============================================================================
+// MAIN RENDER FUNCTION
+// ============================================================================
+
+/**
+ * Render Team Builder page
+ */
+export async function renderTeamBuilder() {
+    const container = document.getElementById('app-container');
+
+    // Check if we have a cached team
+    const cachedTeamId = localStorage.getItem('fplanner_team_id');
+
+    if (!cachedTeamId) {
+        container.innerHTML = `
+            <div style="text-align: center; padding: 4rem 2rem;">
+                <h2 style="color: var(--text-primary); margin-bottom: 1rem;">Team Builder</h2>
+                <p style="color: var(--text-secondary); margin-bottom: 2rem;">
+                    Please load your team from the "My Team" page first.
+                </p>
+                <button
+                    onclick="window.location.hash = '#my-team'"
+                    style="
+                        padding: 1rem 2rem;
+                        background: var(--primary-color);
+                        color: white;
+                        border: none;
+                        border-radius: 8px;
+                        font-size: 1rem;
+                        font-weight: 600;
+                        cursor: pointer;
+                    "
+                >
+                    <i class="fas fa-arrow-left" style="margin-right: 0.5rem;"></i>Go to My Team
+                </button>
+            </div>
+        `;
+        return;
+    }
+
+    // Load team data
+    container.innerHTML = `
+        <div style="text-align: center; padding: 4rem 2rem; color: var(--text-secondary);">
+            <i class="fas fa-spinner fa-spin" style="font-size: 3rem; margin-bottom: 1rem;"></i>
+            <p>Loading Team Builder...</p>
+        </div>
+    `;
+
+    try {
+        currentTeamData = await loadMyTeam(cachedTeamId);
+
+        // Load saved plans
+        allPlans = loadPlansFromStorage();
+
+        // Filter plans to match current team (in case user switched teams)
+        allPlans = allPlans.filter(plan => {
+            // Check if plan's snapshot matches current team structure
+            return plan.currentTeamSnapshot.picks.length === 15;
+        });
+
+        // Create a default plan if none exist
+        if (allPlans.length === 0) {
+            const defaultPlan = createNewPlan('Plan A', currentTeamData, planningHorizon);
+            allPlans.push(defaultPlan);
+            savePlansToStorage(allPlans);
+        }
+
+        // Set active plan
+        activePlanId = allPlans[0].id;
+        activeGameweek = currentGW + 1;
+
+        renderTeamBuilderContent();
+    } catch (err) {
+        console.error('Failed to load team builder:', err);
+        container.innerHTML = `
+            <div style="text-align: center; padding: 4rem 2rem;">
+                <h2 style="color: var(--text-primary); margin-bottom: 1rem;">Error Loading Team</h2>
+                <p style="color: var(--text-secondary); margin-bottom: 2rem;">
+                    Failed to load your team. Please try again.
+                </p>
+                <button
+                    onclick="window.location.hash = '#my-team'"
+                    style="
+                        padding: 1rem 2rem;
+                        background: var(--primary-color);
+                        color: white;
+                        border: none;
+                        border-radius: 8px;
+                        font-size: 1rem;
+                        font-weight: 600;
+                        cursor: pointer;
+                    "
+                >
+                    <i class="fas fa-arrow-left" style="margin-right: 0.5rem;"></i>Go to My Team
+                </button>
+            </div>
+        `;
+    }
+}
+
+/**
+ * Render main Team Builder content
+ */
+function renderTeamBuilderContent() {
+    const container = document.getElementById('app-container');
+    const activePlan = allPlans.find(p => p.id === activePlanId);
+
+    if (!activePlan) {
+        console.error('No active plan found');
+        return;
+    }
+
+    const html = `
+        <div class="team-builder">
+            <!-- Header -->
+            <div style="margin-bottom: 2rem;">
+                <h1 style="font-size: 2rem; font-weight: 700; color: var(--primary-color); margin-bottom: 0.5rem;">
+                    <i class="fas fa-chess"></i> Team Builder
+                </h1>
+                <p style="color: var(--text-secondary);">
+                    Plan your transfers ahead with free transfer tracking and validation
+                </p>
+            </div>
+
+            <!-- Team Info Card -->
+            ${renderTeamInfoCard()}
+
+            <!-- Plan Tabs -->
+            ${renderPlanTabs()}
+
+            <!-- Transfer Summary Cards -->
+            ${renderTransferSummary(activePlan)}
+
+            <!-- Planning Horizon Control -->
+            ${renderPlanningHorizonControl(activePlan)}
+
+            <!-- Gameweek Tabs -->
+            ${renderGameweekTabs(activePlan)}
+
+            <!-- Active Gameweek Content -->
+            ${renderGameweekContent(activePlan, activeGameweek)}
+
+            <!-- Projected Squad -->
+            ${renderProjectedSquad(activePlan, activeGameweek)}
+
+            <!-- Action Buttons -->
+            ${renderActionButtons()}
+        </div>
+    `;
+
+    container.innerHTML = html;
+
+    // Attach event listeners
+    attachEventListeners();
+    attachRiskTooltipListeners();
+}
+
+// ============================================================================
+// COMPONENT RENDERERS
+// ============================================================================
+
+/**
+ * Render team info card
+ */
+function renderTeamInfoCard() {
+    const team = currentTeamData.team;
+    const entry = currentTeamData.picks.entry_history;
+
+    return `
+        <div style="
+            background: linear-gradient(135deg, var(--primary-color) 0%, var(--accent-color) 100%);
+            padding: 1.5rem 2rem;
+            border-radius: 12px;
+            color: white;
+            box-shadow: 0 4px 12px var(--shadow);
+            margin-bottom: 2rem;
+        ">
+            <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1.5rem;">
+                <div>
+                    <div style="font-size: 0.875rem; opacity: 0.9; margin-bottom: 0.25rem;">Manager</div>
+                    <div style="font-size: 1.25rem; font-weight: 700;">${escapeHtml(team.player_first_name)} ${escapeHtml(team.player_last_name)}</div>
+                    <div style="font-size: 0.875rem; opacity: 0.8; margin-top: 0.25rem;">${escapeHtml(team.name)}</div>
+                </div>
+                <div>
+                    <div style="font-size: 0.875rem; opacity: 0.9; margin-bottom: 0.25rem;">Current GW</div>
+                    <div style="font-size: 1.25rem; font-weight: 700;">GW${currentGW}</div>
+                    <div style="font-size: 0.875rem; opacity: 0.8; margin-top: 0.25rem;">Planning from GW${currentGW + 1}</div>
+                </div>
+                <div>
+                    <div style="font-size: 0.875rem; opacity: 0.9; margin-bottom: 0.25rem;">Team Value</div>
+                    <div style="font-size: 1.25rem; font-weight: 700;">£${(entry.value / 10).toFixed(1)}m</div>
+                    <div style="font-size: 0.875rem; opacity: 0.8; margin-top: 0.25rem;">Bank: £${(entry.bank / 10).toFixed(1)}m</div>
+                </div>
+            </div>
+        </div>
+    `;
+}
+
+/**
+ * Render plan tabs
+ */
+function renderPlanTabs() {
+    const tabs = allPlans.map(plan => {
+        const isActive = plan.id === activePlanId;
+        return `
+            <button
+                class="plan-tab"
+                data-plan-id="${plan.id}"
+                style="
+                    padding: 0.75rem 1.5rem;
+                    border: none;
+                    background: ${isActive ? 'var(--primary-color)' : 'var(--bg-secondary)'};
+                    color: ${isActive ? 'white' : 'var(--text-primary)'};
+                    font-weight: ${isActive ? '700' : '500'};
+                    border-radius: 8px 8px 0 0;
+                    cursor: pointer;
+                    transition: all 0.2s;
+                "
+            >
+                ${escapeHtml(plan.name)}
+            </button>
+        `;
+    }).join('');
+
+    return `
+        <div style="margin-bottom: 2rem;">
+            <div style="display: flex; gap: 0.5rem; border-bottom: 2px solid var(--border-color);">
+                ${tabs}
+                <button
+                    id="new-plan-btn"
+                    style="
+                        padding: 0.75rem 1.5rem;
+                        border: 2px dashed var(--border-color);
+                        background: transparent;
+                        color: var(--text-secondary);
+                        font-weight: 500;
+                        border-radius: 8px 8px 0 0;
+                        cursor: pointer;
+                        transition: all 0.2s;
+                    "
+                >
+                    <i class="fas fa-plus"></i> New Plan
+                </button>
+            </div>
+        </div>
+    `;
+}
+
+/**
+ * Render transfer summary cards
+ */
+function renderTransferSummary(plan) {
+    // Calculate totals across all gameweeks
+    let totalTransfers = 0;
+    let totalPointsHit = 0;
+    let totalFreeTransfers = 0;
+
+    Object.values(plan.gameweekPlans).forEach(gwPlan => {
+        totalTransfers += gwPlan.transfers.length;
+        totalPointsHit += gwPlan.pointsHit;
+        totalFreeTransfers += gwPlan.freeTransfers;
+    });
+
+    // Get projected squad for last GW
+    const lastGW = Math.max(...Object.keys(plan.gameweekPlans).map(Number));
+    const projected = calculateProjectedSquad(plan, lastGW);
+    const validation = validateSquad(plan, lastGW);
+
+    return `
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin-bottom: 2rem;">
+            <!-- Total Transfers -->
+            <div style="
+                background: var(--bg-primary);
+                padding: 1.5rem;
+                border-radius: 12px;
+                border-left: 4px solid var(--primary-color);
+                box-shadow: 0 2px 8px var(--shadow);
+            ">
+                <div style="font-size: 0.75rem; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.5rem;">
+                    Planned Transfers
+                </div>
+                <div style="font-size: 2rem; font-weight: 700; color: var(--text-primary);">
+                    ${totalTransfers}
+                </div>
+                <div style="font-size: 0.75rem; color: var(--text-secondary); margin-top: 0.25rem;">
+                    ${totalFreeTransfers} free, ${totalTransfers - totalFreeTransfers} extra
+                </div>
+            </div>
+
+            <!-- Points Hit -->
+            <div style="
+                background: var(--bg-primary);
+                padding: 1.5rem;
+                border-radius: 12px;
+                border-left: 4px solid ${totalPointsHit < 0 ? '#ef4444' : '#22c55e'};
+                box-shadow: 0 2px 8px var(--shadow);
+            ">
+                <div style="font-size: 0.75rem; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.5rem;">
+                    Points Hit
+                </div>
+                <div style="font-size: 2rem; font-weight: 700; color: ${totalPointsHit < 0 ? '#ef4444' : 'var(--text-primary)'};">
+                    ${totalPointsHit}
+                </div>
+                <div style="font-size: 0.75rem; color: var(--text-secondary); margin-top: 0.25rem;">
+                    ${totalPointsHit === 0 ? '✓ No hits taken' : `${Math.abs(totalPointsHit / 4)} extra transfer${Math.abs(totalPointsHit / 4) !== 1 ? 's' : ''}`}
+                </div>
+            </div>
+
+            <!-- Remaining Budget -->
+            <div style="
+                background: var(--bg-primary);
+                padding: 1.5rem;
+                border-radius: 12px;
+                border-left: 4px solid ${projected.bank < 0 ? '#ef4444' : '#22c55e'};
+                box-shadow: 0 2px 8px var(--shadow);
+            ">
+                <div style="font-size: 0.75rem; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.5rem;">
+                    Remaining Budget
+                </div>
+                <div style="font-size: 2rem; font-weight: 700; color: ${projected.bank < 0 ? '#ef4444' : 'var(--text-primary)'};">
+                    £${Math.abs(projected.bank / 10).toFixed(1)}m
+                </div>
+                <div style="font-size: 0.75rem; color: var(--text-secondary); margin-top: 0.25rem;">
+                    ${projected.bank < 0 ? '⚠️ Over budget!' : 'In the bank'}
+                </div>
+            </div>
+
+            <!-- Validation Status -->
+            <div style="
+                background: var(--bg-primary);
+                padding: 1.5rem;
+                border-radius: 12px;
+                border-left: 4px solid ${validation.valid ? '#22c55e' : '#ef4444'};
+                box-shadow: 0 2px 8px var(--shadow);
+            ">
+                <div style="font-size: 0.75rem; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.5rem;">
+                    Squad Status
+                </div>
+                <div style="font-size: 2rem; font-weight: 700; color: ${validation.valid ? '#22c55e' : '#ef4444'};">
+                    ${validation.valid ? '✓' : '✗'}
+                </div>
+                <div style="font-size: 0.75rem; color: var(--text-secondary); margin-top: 0.25rem;">
+                    ${validation.valid ? 'Valid squad' : `${validation.errors.length} error${validation.errors.length !== 1 ? 's' : ''}`}
+                </div>
+            </div>
+        </div>
+    `;
+}
+
+/**
+ * Render planning horizon control
+ */
+function renderPlanningHorizonControl(plan) {
+    return `
+        <div style="margin-bottom: 2rem; display: flex; align-items: center; gap: 1rem;">
+            <label style="font-weight: 600; color: var(--text-primary);">
+                Planning Horizon:
+            </label>
+            <select
+                id="planning-horizon-select"
+                style="
+                    padding: 0.5rem 1rem;
+                    border: 2px solid var(--border-color);
+                    border-radius: 8px;
+                    background: var(--bg-primary);
+                    color: var(--text-primary);
+                    font-size: 1rem;
+                    cursor: pointer;
+                "
+            >
+                ${[3, 4, 5, 6, 7, 8].map(n => `
+                    <option value="${n}" ${plan.planningHorizon === n ? 'selected' : ''}>
+                        ${n} Gameweeks
+                    </option>
+                `).join('')}
+            </select>
+            <span style="color: var(--text-secondary); font-size: 0.875rem;">
+                (GW${plan.startGW} to GW${plan.startGW + plan.planningHorizon - 1})
+            </span>
+        </div>
+    `;
+}
+
+/**
+ * Render gameweek tabs
+ */
+function renderGameweekTabs(plan) {
+    const gameweeks = Object.keys(plan.gameweekPlans).sort((a, b) => a - b);
+
+    const tabs = gameweeks.map(gw => {
+        const gwNum = parseInt(gw);
+        const isActive = gwNum === activeGameweek;
+        const gwPlan = plan.gameweekPlans[gw];
+        const transferCount = gwPlan.transfers.length;
+
+        return `
+            <button
+                class="gw-tab"
+                data-gw="${gwNum}"
+                style="
+                    padding: 0.75rem 1.5rem;
+                    border: 2px solid ${isActive ? 'var(--primary-color)' : 'var(--border-color)'};
+                    background: ${isActive ? 'var(--primary-color)' : 'var(--bg-primary)'};
+                    color: ${isActive ? 'white' : 'var(--text-primary)'};
+                    font-weight: ${isActive ? '700' : '500'};
+                    border-radius: 8px;
+                    cursor: pointer;
+                    transition: all 0.2s;
+                    position: relative;
+                "
+            >
+                GW${gwNum}
+                ${transferCount > 0 ? `
+                    <span style="
+                        position: absolute;
+                        top: -8px;
+                        right: -8px;
+                        background: ${gwPlan.pointsHit < 0 ? '#ef4444' : '#22c55e'};
+                        color: white;
+                        width: 20px;
+                        height: 20px;
+                        border-radius: 50%;
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
+                        font-size: 0.75rem;
+                        font-weight: 700;
+                    ">
+                        ${transferCount}
+                    </span>
+                ` : ''}
+                ${gwPlan.chipUsed ? `
+                    <span style="
+                        display: block;
+                        font-size: 0.65rem;
+                        opacity: 0.9;
+                        margin-top: 2px;
+                    ">
+                        ${gwPlan.chipUsed.toUpperCase()}
+                    </span>
+                ` : ''}
+            </button>
+        `;
+    }).join('');
+
+    return `
+        <div style="margin-bottom: 2rem;">
+            <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+                ${tabs}
+            </div>
+        </div>
+    `;
+}
+
+/**
+ * Render gameweek content (transfers + suggestions)
+ */
+function renderGameweekContent(plan, gameweek) {
+    const gwPlan = plan.gameweekPlans[gameweek];
+    if (!gwPlan) return '';
+
+    const usedChips = currentTeamData.team.chips || [];
+    const availableChips = getAvailableChips(currentTeamData);
+
+    return `
+        <div style="margin-bottom: 2rem;">
+            <!-- Chip Selection -->
+            ${renderChipSelector(plan, gameweek, availableChips, usedChips)}
+
+            <!-- Transfer List -->
+            <div style="
+                background: var(--bg-primary);
+                border-radius: 12px;
+                padding: 1.5rem;
+                box-shadow: 0 2px 8px var(--shadow);
+                margin-bottom: 1rem;
+            ">
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
+                    <h3 style="font-size: 1.125rem; font-weight: 700; color: var(--text-primary); margin: 0;">
+                        Transfers for GW${gameweek}
+                    </h3>
+                    <div style="display: flex; gap: 0.5rem; align-items: center;">
+                        <span style="font-size: 0.875rem; color: var(--text-secondary);">
+                            Free Transfers: <strong>${gwPlan.freeTransfers}</strong>
+                        </span>
+                        ${gwPlan.pointsHit < 0 ? `
+                            <span style="font-size: 0.875rem; color: #ef4444; font-weight: 600;">
+                                ${gwPlan.pointsHit} pts
+                            </span>
+                        ` : ''}
+                    </div>
+                </div>
+
+                ${gwPlan.transfers.length === 0 ? `
+                    <div style="text-align: center; padding: 2rem; color: var(--text-secondary);">
+                        <i class="fas fa-exchange-alt" style="font-size: 2rem; margin-bottom: 0.5rem; opacity: 0.5;"></i>
+                        <p>No transfers planned for this gameweek</p>
+                    </div>
+                ` : `
+                    <div style="display: flex; flex-direction: column; gap: 0.75rem;">
+                        ${gwPlan.transfers.map((transfer, idx) => renderTransferRow(transfer, idx, gameweek)).join('')}
+                    </div>
+                `}
+
+                <button
+                    id="add-transfer-btn"
+                    style="
+                        width: 100%;
+                        padding: 0.75rem;
+                        margin-top: 1rem;
+                        border: 2px dashed var(--border-color);
+                        background: var(--bg-secondary);
+                        color: var(--text-primary);
+                        border-radius: 8px;
+                        font-weight: 600;
+                        cursor: pointer;
+                        transition: all 0.2s;
+                    "
+                >
+                    <i class="fas fa-plus"></i> Add Transfer
+                </button>
+            </div>
+
+            <!-- Auto-Suggestions -->
+            ${renderAutoSuggestions(plan, gameweek)}
+        </div>
+    `;
+}
+
+/**
+ * Render chip selector dropdown
+ */
+function renderChipSelector(plan, gameweek, availableChips, usedChips) {
+    const gwPlan = plan.gameweekPlans[gameweek];
+    const currentChip = gwPlan.chipUsed;
+
+    return `
+        <div style="margin-bottom: 1rem;">
+            <label style="font-weight: 600; color: var(--text-primary); margin-right: 0.5rem;">
+                Chip:
+            </label>
+            <select
+                id="chip-select-${gameweek}"
+                class="chip-select"
+                data-gw="${gameweek}"
+                style="
+                    padding: 0.5rem 1rem;
+                    border: 2px solid var(--border-color);
+                    border-radius: 8px;
+                    background: var(--bg-primary);
+                    color: var(--text-primary);
+                    font-size: 0.875rem;
+                    cursor: pointer;
+                "
+            >
+                <option value="">None</option>
+                ${availableChips.map(chip => `
+                    <option value="${chip}" ${currentChip === chip ? 'selected' : ''}>
+                        ${chip.charAt(0).toUpperCase() + chip.slice(1)}
+                    </option>
+                `).join('')}
+            </select>
+            ${currentChip ? `
+                <span style="margin-left: 0.5rem; font-size: 0.875rem; color: var(--text-secondary);">
+                    ${currentChip === 'wildcard' || currentChip === 'freehit' ? '✓ Unlimited transfers' : ''}
+                </span>
+            ` : ''}
+        </div>
+    `;
+}
+
+/**
+ * Render a single transfer row
+ */
+function renderTransferRow(transfer, index, gameweek) {
+    const playerOut = getPlayerById(transfer.out);
+    const playerIn = getPlayerById(transfer.in);
+
+    if (!playerOut || !playerIn) return '';
+
+    const priceDiff = playerIn.now_cost - playerOut.now_cost;
+    const diffSign = priceDiff >= 0 ? '+' : '';
+    const diffColor = priceDiff < 0 ? '#22c55e' : '#ef4444';
+
+    return `
+        <div style="
+            display: grid;
+            grid-template-columns: 1fr auto 1fr auto;
+            gap: 1rem;
+            align-items: center;
+            padding: 1rem;
+            background: var(--bg-secondary);
+            border-radius: 8px;
+        ">
+            <!-- Player Out -->
+            <div>
+                <div style="font-size: 0.75rem; color: var(--text-secondary); margin-bottom: 0.25rem;">OUT</div>
+                <div style="font-weight: 600; color: var(--text-primary);">
+                    ${escapeHtml(playerOut.web_name)}
+                </div>
+                <div style="font-size: 0.875rem; color: var(--text-secondary);">
+                    ${getTeamShortName(playerOut.team)} • ${formatCurrency(playerOut.now_cost)}
+                </div>
+            </div>
+
+            <!-- Arrow -->
+            <div>
+                <i class="fas fa-arrow-right" style="color: var(--primary-color); font-size: 1.25rem;"></i>
+            </div>
+
+            <!-- Player In -->
+            <div>
+                <div style="font-size: 0.75rem; color: var(--text-secondary); margin-bottom: 0.25rem;">IN</div>
+                <div style="font-weight: 600; color: var(--text-primary);">
+                    ${escapeHtml(playerIn.web_name)}
+                </div>
+                <div style="font-size: 0.875rem; color: var(--text-secondary);">
+                    ${getTeamShortName(playerIn.team)} • ${formatCurrency(playerIn.now_cost)}
+                </div>
+            </div>
+
+            <!-- Actions -->
+            <div style="display: flex; flex-direction: column; align-items: flex-end; gap: 0.5rem;">
+                <div style="font-size: 0.875rem; font-weight: 600; color: ${diffColor};">
+                    ${diffSign}£${Math.abs(priceDiff / 10).toFixed(1)}m
+                </div>
+                <button
+                    class="remove-transfer-btn"
+                    data-gw="${gameweek}"
+                    data-index="${index}"
+                    style="
+                        padding: 0.25rem 0.75rem;
+                        background: #ef4444;
+                        color: white;
+                        border: none;
+                        border-radius: 6px;
+                        font-size: 0.75rem;
+                        cursor: pointer;
+                        transition: all 0.2s;
+                    "
+                >
+                    <i class="fas fa-times"></i> Remove
+                </button>
+            </div>
+        </div>
+    `;
+}
+
+/**
+ * Render auto-suggestions panel
+ */
+function renderAutoSuggestions(plan, gameweek) {
+    const suggestions = findSuggestedTransfers(plan, gameweek, 5);
+
+    if (suggestions.length === 0) {
+        return '';
+    }
+
+    const priorityColor = {
+        high: '#ef4444',
+        medium: '#fb923c',
+        low: '#3b82f6'
+    };
+
+    return `
+        <div style="
+            background: var(--bg-primary);
+            border-radius: 12px;
+            padding: 1.5rem;
+            box-shadow: 0 2px 8px var(--shadow);
+            border-left: 4px solid #3b82f6;
+        ">
+            <h3 style="font-size: 1.125rem; font-weight: 700; color: var(--text-primary); margin-bottom: 1rem;">
+                <i class="fas fa-lightbulb"></i> Suggested Transfers
+            </h3>
+
+            <div style="display: flex; flex-direction: column; gap: 0.75rem;">
+                ${suggestions.map((sug, idx) => `
+                    <div style="
+                        display: flex;
+                        justify-content: space-between;
+                        align-items: center;
+                        padding: 1rem;
+                        background: var(--bg-secondary);
+                        border-radius: 8px;
+                        border-left: 3px solid ${priorityColor[sug.priority]};
+                    ">
+                        <div style="flex: 1;">
+                            <div style="font-size: 0.75rem; color: ${priorityColor[sug.priority]}; font-weight: 600; text-transform: uppercase; margin-bottom: 0.25rem;">
+                                ${sug.type} • ${sug.priority} priority
+                            </div>
+                            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 0.25rem;">
+                                ${escapeHtml(sug.playerOut.web_name)} → ${escapeHtml(sug.playerIn.web_name)}
+                            </div>
+                            <div style="font-size: 0.875rem; color: var(--text-secondary);">
+                                ${sug.reason}
+                            </div>
+                        </div>
+                        <button
+                            class="apply-suggestion-btn"
+                            data-out="${sug.playerOut.id}"
+                            data-in="${sug.playerIn.id}"
+                            data-gw="${gameweek}"
+                            style="
+                                padding: 0.5rem 1rem;
+                                background: var(--primary-color);
+                                color: white;
+                                border: none;
+                                border-radius: 6px;
+                                font-size: 0.875rem;
+                                font-weight: 600;
+                                cursor: pointer;
+                                transition: all 0.2s;
+                                white-space: nowrap;
+                            "
+                        >
+                            <i class="fas fa-check"></i> Apply
+                        </button>
+                    </div>
+                `).join('')}
+            </div>
+        </div>
+    `;
+}
+
+/**
+ * Render projected squad table
+ */
+function renderProjectedSquad(plan, gameweek) {
+    const { squad, bank, value } = calculateProjectedSquad(plan, gameweek);
+    const validation = validateSquad(plan, gameweek);
+
+    // Sort by position
+    const sortedSquad = [...squad].sort((a, b) => {
+        const playerA = getPlayerById(a.element);
+        const playerB = getPlayerById(b.element);
+        if (!playerA || !playerB) return 0;
+
+        // Sort by position type, then by price
+        const posOrder = { 1: 0, 2: 1, 3: 2, 4: 3 }; // GKP, DEF, MID, FWD
+        const posCompare = posOrder[playerA.element_type] - posOrder[playerB.element_type];
+        if (posCompare !== 0) return posCompare;
+
+        return playerB.now_cost - playerA.now_cost;
+    });
+
+    return `
+        <div style="margin-bottom: 2rem;">
+            <h3 style="font-size: 1.125rem; font-weight: 700; color: var(--text-primary); margin-bottom: 1rem;">
+                <i class="fas fa-users"></i> Projected Squad (After GW${gameweek})
+            </h3>
+
+            ${validation.errors.length > 0 ? `
+                <div style="
+                    background: rgba(239, 68, 68, 0.1);
+                    border-left: 4px solid #ef4444;
+                    padding: 1rem;
+                    border-radius: 8px;
+                    margin-bottom: 1rem;
+                ">
+                    <div style="font-weight: 600; color: #ef4444; margin-bottom: 0.5rem;">
+                        <i class="fas fa-exclamation-triangle"></i> Validation Errors:
+                    </div>
+                    <ul style="margin: 0; padding-left: 1.5rem; color: #ef4444;">
+                        ${validation.errors.map(err => `<li>${err}</li>`).join('')}
+                    </ul>
+                </div>
+            ` : ''}
+
+            <div style="
+                background: var(--bg-primary);
+                border-radius: 12px;
+                padding: 1rem;
+                box-shadow: 0 2px 8px var(--shadow);
+            ">
+                <div style="margin-bottom: 1rem; display: flex; justify-content: space-between; align-items: center;">
+                    <div>
+                        <span style="font-weight: 600; color: var(--text-primary);">Total Value:</span>
+                        <span style="margin-left: 0.5rem; color: var(--text-secondary);">£${(value / 10).toFixed(1)}m</span>
+                    </div>
+                    <div>
+                        <span style="font-weight: 600; color: var(--text-primary);">Bank:</span>
+                        <span style="margin-left: 0.5rem; color: ${bank < 0 ? '#ef4444' : 'var(--text-secondary)'};">£${(bank / 10).toFixed(1)}m</span>
+                    </div>
+                </div>
+
+                <div style="overflow-x: auto;">
+                    <table style="width: 100%; font-size: 0.875rem; border-collapse: collapse;">
+                        <thead style="background: var(--primary-color); color: white;">
+                            <tr>
+                                <th style="text-align: left; padding: 0.75rem 0.5rem;">Pos</th>
+                                <th style="text-align: left; padding: 0.75rem 0.5rem;">Player</th>
+                                <th style="text-align: left; padding: 0.75rem 0.5rem;">Team</th>
+                                <th style="text-align: center; padding: 0.75rem 0.5rem;">Price</th>
+                                <th style="text-align: center; padding: 0.75rem 0.5rem;">Form</th>
+                                <th style="text-align: center; padding: 0.75rem 0.5rem;">PPM</th>
+                                <th style="text-align: center; padding: 0.75rem 0.5rem;">FDR (5)</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            ${sortedSquad.map((pick, idx) => {
+                                const player = getPlayerById(pick.element);
+                                if (!player) return '';
+
+                                const rowBg = idx % 2 === 0 ? 'var(--bg-secondary)' : 'var(--bg-primary)';
+                                const ppm = calculatePPM(player);
+                                const fdr = calculateFixtureDifficulty(player.team, 5);
+                                const fdrColor = fdr <= 2.5 ? '#22c55e' : fdr <= 3.5 ? '#fb923c' : '#ef4444';
+
+                                const risks = analyzePlayerRisks(player);
+                                const riskTooltip = renderRiskTooltip(risks);
+                                const hasRisk = hasHighRisk(risks);
+
+                                return `
+                                    <tr style="background: ${hasRisk ? 'rgba(239, 68, 68, 0.05)' : rowBg};">
+                                        <td style="padding: 0.75rem 0.5rem; font-weight: 600;">${getPositionShort(player)}</td>
+                                        <td style="padding: 0.75rem 0.5rem;">
+                                            <strong>${escapeHtml(player.web_name)}</strong>
+                                            ${riskTooltip ? `${riskTooltip}` : ''}
+                                        </td>
+                                        <td style="padding: 0.75rem 0.5rem;">${getTeamShortName(player.team)}</td>
+                                        <td style="padding: 0.75rem 0.5rem; text-align: center;">${formatCurrency(player.now_cost)}</td>
+                                        <td style="padding: 0.75rem 0.5rem; text-align: center; font-weight: 600;">${formatDecimal(player.form)}</td>
+                                        <td style="padding: 0.75rem 0.5rem; text-align: center; font-weight: 600;">${formatDecimal(ppm)}</td>
+                                        <td style="padding: 0.75rem 0.5rem; text-align: center;">
+                                            <span style="color: ${fdrColor}; font-weight: 600;">
+                                                ${fdr.toFixed(1)}
+                                            </span>
+                                        </td>
+                                    </tr>
+                                `;
+                            }).join('')}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    `;
+}
+
+/**
+ * Render action buttons
+ */
+function renderActionButtons() {
+    return `
+        <div style="display: flex; gap: 1rem; justify-content: flex-end;">
+            <button
+                id="delete-plan-btn"
+                style="
+                    padding: 0.75rem 1.5rem;
+                    background: #ef4444;
+                    color: white;
+                    border: none;
+                    border-radius: 8px;
+                    font-weight: 600;
+                    cursor: pointer;
+                    transition: all 0.2s;
+                "
+            >
+                <i class="fas fa-trash"></i> Delete Plan
+            </button>
+            <button
+                id="save-plan-btn"
+                style="
+                    padding: 0.75rem 1.5rem;
+                    background: var(--primary-color);
+                    color: white;
+                    border: none;
+                    border-radius: 8px;
+                    font-weight: 600;
+                    cursor: pointer;
+                    transition: all 0.2s;
+                "
+            >
+                <i class="fas fa-save"></i> Save Changes
+            </button>
+        </div>
+    `;
+}
+
+// ============================================================================
+// EVENT HANDLERS
+// ============================================================================
+
+/**
+ * Attach all event listeners
+ */
+function attachEventListeners() {
+    // Plan tabs
+    document.querySelectorAll('.plan-tab').forEach(btn => {
+        btn.addEventListener('click', () => {
+            activePlanId = btn.dataset.planId;
+            renderTeamBuilderContent();
+        });
+    });
+
+    // New plan button
+    const newPlanBtn = document.getElementById('new-plan-btn');
+    if (newPlanBtn) {
+        newPlanBtn.addEventListener('click', handleNewPlan);
+    }
+
+    // Gameweek tabs
+    document.querySelectorAll('.gw-tab').forEach(btn => {
+        btn.addEventListener('click', () => {
+            activeGameweek = parseInt(btn.dataset.gw);
+            renderTeamBuilderContent();
+        });
+    });
+
+    // Add transfer button
+    const addTransferBtn = document.getElementById('add-transfer-btn');
+    if (addTransferBtn) {
+        addTransferBtn.addEventListener('click', () => openPlayerSelectModal(null));
+    }
+
+    // Remove transfer buttons
+    document.querySelectorAll('.remove-transfer-btn').forEach(btn => {
+        btn.addEventListener('click', handleRemoveTransfer);
+    });
+
+    // Apply suggestion buttons
+    document.querySelectorAll('.apply-suggestion-btn').forEach(btn => {
+        btn.addEventListener('click', handleApplySuggestion);
+    });
+
+    // Chip selectors
+    document.querySelectorAll('.chip-select').forEach(select => {
+        select.addEventListener('change', handleChipChange);
+    });
+
+    // Planning horizon select
+    const horizonSelect = document.getElementById('planning-horizon-select');
+    if (horizonSelect) {
+        horizonSelect.addEventListener('change', handlePlanningHorizonChange);
+    }
+
+    // Save plan button
+    const savePlanBtn = document.getElementById('save-plan-btn');
+    if (savePlanBtn) {
+        savePlanBtn.addEventListener('click', handleSavePlan);
+    }
+
+    // Delete plan button
+    const deletePlanBtn = document.getElementById('delete-plan-btn');
+    if (deletePlanBtn) {
+        deletePlanBtn.addEventListener('click', handleDeletePlan);
+    }
+}
+
+/**
+ * Handle new plan creation
+ */
+function handleNewPlan() {
+    const planName = prompt('Enter plan name:', `Plan ${String.fromCharCode(65 + allPlans.length)}`);
+    if (!planName) return;
+
+    const activePlan = allPlans.find(p => p.id === activePlanId);
+    const horizon = activePlan ? activePlan.planningHorizon : 3;
+
+    const newPlan = createNewPlan(planName, currentTeamData, horizon);
+    allPlans.push(newPlan);
+    activePlanId = newPlan.id;
+
+    savePlansToStorage(allPlans);
+    renderTeamBuilderContent();
+}
+
+/**
+ * Handle remove transfer
+ */
+function handleRemoveTransfer(e) {
+    const btn = e.currentTarget;
+    const gw = parseInt(btn.dataset.gw);
+    const index = parseInt(btn.dataset.index);
+
+    const activePlan = allPlans.find(p => p.id === activePlanId);
+    if (!activePlan) return;
+
+    const updatedPlan = removeTransfer(activePlan, gw, index);
+
+    // Update plan in array
+    const planIndex = allPlans.findIndex(p => p.id === activePlanId);
+    allPlans[planIndex] = updatedPlan;
+
+    savePlansToStorage(allPlans);
+    renderTeamBuilderContent();
+}
+
+/**
+ * Handle apply suggestion
+ */
+function handleApplySuggestion(e) {
+    const btn = e.currentTarget;
+    const playerOutId = parseInt(btn.dataset.out);
+    const playerInId = parseInt(btn.dataset.in);
+    const gw = parseInt(btn.dataset.gw);
+
+    const activePlan = allPlans.find(p => p.id === activePlanId);
+    if (!activePlan) return;
+
+    const result = addTransfer(activePlan, gw, playerOutId, playerInId);
+
+    if (result.success) {
+        // Update plan in array
+        const planIndex = allPlans.findIndex(p => p.id === activePlanId);
+        allPlans[planIndex] = result.updatedPlan;
+
+        savePlansToStorage(allPlans);
+        renderTeamBuilderContent();
+    } else {
+        alert(`Failed to add transfer: ${result.error}`);
+    }
+}
+
+/**
+ * Handle chip change
+ */
+function handleChipChange(e) {
+    const select = e.currentTarget;
+    const gw = parseInt(select.dataset.gw);
+    const chipName = select.value || null;
+
+    const activePlan = allPlans.find(p => p.id === activePlanId);
+    if (!activePlan) return;
+
+    const usedChips = currentTeamData.team.chips || [];
+    const result = setChip(activePlan, gw, chipName, usedChips);
+
+    if (result.success) {
+        // Update plan in array
+        const planIndex = allPlans.findIndex(p => p.id === activePlanId);
+        allPlans[planIndex] = result.updatedPlan;
+
+        savePlansToStorage(allPlans);
+        renderTeamBuilderContent();
+    } else {
+        alert(`Failed to set chip: ${result.error}`);
+        select.value = activePlan.gameweekPlans[gw].chipUsed || '';
+    }
+}
+
+/**
+ * Handle planning horizon change
+ */
+function handlePlanningHorizonChange(e) {
+    const newHorizon = parseInt(e.target.value);
+
+    const activePlan = allPlans.find(p => p.id === activePlanId);
+    if (!activePlan) return;
+
+    // Update plan horizon
+    const startGW = activePlan.startGW;
+    const oldHorizon = activePlan.planningHorizon;
+
+    // Add new GWs if expanding
+    if (newHorizon > oldHorizon) {
+        for (let i = oldHorizon; i < newHorizon; i++) {
+            const gw = startGW + i;
+            activePlan.gameweekPlans[gw] = {
+                transfers: [],
+                freeTransfers: 0,
+                pointsHit: 0,
+                chipUsed: null
+            };
+        }
+    }
+    // Remove GWs if contracting
+    else if (newHorizon < oldHorizon) {
+        for (let i = newHorizon; i < oldHorizon; i++) {
+            const gw = startGW + i;
+            delete activePlan.gameweekPlans[gw];
+        }
+    }
+
+    activePlan.planningHorizon = newHorizon;
+    activePlan.modified = new Date().toISOString();
+
+    // Update plan in array
+    const planIndex = allPlans.findIndex(p => p.id === activePlanId);
+    allPlans[planIndex] = activePlan;
+
+    // Ensure active GW is still valid
+    if (activeGameweek > startGW + newHorizon - 1) {
+        activeGameweek = startGW + newHorizon - 1;
+    }
+
+    savePlansToStorage(allPlans);
+    renderTeamBuilderContent();
+}
+
+/**
+ * Handle save plan
+ */
+function handleSavePlan() {
+    savePlansToStorage(allPlans);
+    alert('Plan saved successfully!');
+}
+
+/**
+ * Handle delete plan
+ */
+function handleDeletePlan() {
+    if (allPlans.length === 1) {
+        alert('Cannot delete the last plan. Create a new plan first.');
+        return;
+    }
+
+    const confirmed = confirm('Are you sure you want to delete this plan?');
+    if (!confirmed) return;
+
+    deletePlanFromStorage(activePlanId);
+    allPlans = allPlans.filter(p => p.id !== activePlanId);
+
+    activePlanId = allPlans[0].id;
+
+    renderTeamBuilderContent();
+}
+
+/**
+ * Open player selection modal
+ * @param {number|null} playerOutId - If null, show all squad players to select from
+ */
+function openPlayerSelectModal(playerOutId) {
+    transferOutPlayerId = playerOutId;
+
+    // Show modal with player search
+    const activePlan = allPlans.find(p => p.id === activePlanId);
+    if (!activePlan) return;
+
+    const { squad, bank } = calculateProjectedSquad(activePlan, activeGameweek - 1);
+
+    // If no player selected yet, show squad to pick from
+    if (!playerOutId) {
+        showSquadSelectionModal(squad);
+    } else {
+        // Show replacement options
+        const playerOut = getPlayerById(playerOutId);
+        if (!playerOut) return;
+
+        showReplacementSelectionModal(playerOut, squad, bank);
+    }
+}
+
+/**
+ * Show squad selection modal (pick player to transfer out)
+ */
+function showSquadSelectionModal(squad) {
+    const modalHtml = `
+        <div id="player-modal" style="
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0, 0, 0, 0.7);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 1000;
+        ">
+            <div style="
+                background: var(--bg-primary);
+                border-radius: 12px;
+                padding: 2rem;
+                max-width: 800px;
+                max-height: 80vh;
+                overflow-y: auto;
+                box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+            ">
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem;">
+                    <h3 style="font-size: 1.25rem; font-weight: 700; color: var(--text-primary); margin: 0;">
+                        Select Player to Transfer Out
+                    </h3>
+                    <button
+                        id="close-modal-btn"
+                        style="
+                            background: none;
+                            border: none;
+                            font-size: 1.5rem;
+                            color: var(--text-secondary);
+                            cursor: pointer;
+                        "
+                    >
+                        <i class="fas fa-times"></i>
+                    </button>
+                </div>
+
+                <div style="display: grid; gap: 0.5rem;">
+                    ${squad.map(pick => {
+                        const player = getPlayerById(pick.element);
+                        if (!player) return '';
+
+                        return `
+                            <button
+                                class="select-player-out-btn"
+                                data-player-id="${player.id}"
+                                style="
+                                    display: flex;
+                                    justify-content: space-between;
+                                    align-items: center;
+                                    padding: 1rem;
+                                    background: var(--bg-secondary);
+                                    border: 2px solid var(--border-color);
+                                    border-radius: 8px;
+                                    cursor: pointer;
+                                    transition: all 0.2s;
+                                    text-align: left;
+                                "
+                            >
+                                <div>
+                                    <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 0.25rem;">
+                                        ${escapeHtml(player.web_name)}
+                                    </div>
+                                    <div style="font-size: 0.875rem; color: var(--text-secondary);">
+                                        ${getPositionShort(player)} • ${getTeamShortName(player.team)} • ${formatCurrency(player.now_cost)}
+                                    </div>
+                                </div>
+                                <div style="text-align: right;">
+                                    <div style="font-size: 0.875rem; color: var(--text-secondary);">Form: ${formatDecimal(player.form)}</div>
+                                    <div style="font-size: 0.875rem; color: var(--text-secondary);">PPM: ${formatDecimal(calculatePPM(player))}</div>
+                                </div>
+                            </button>
+                        `;
+                    }).join('')}
+                </div>
+            </div>
+        </div>
+    `;
+
+    document.body.insertAdjacentHTML('beforeend', modalHtml);
+
+    // Attach event listeners
+    document.getElementById('close-modal-btn').addEventListener('click', closePlayerModal);
+    document.querySelectorAll('.select-player-out-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const playerId = parseInt(btn.dataset.playerId);
+            closePlayerModal();
+            openPlayerSelectModal(playerId);
+        });
+
+        btn.addEventListener('mouseenter', e => {
+            e.currentTarget.style.borderColor = 'var(--primary-color)';
+        });
+        btn.addEventListener('mouseleave', e => {
+            e.currentTarget.style.borderColor = 'var(--border-color)';
+        });
+    });
+}
+
+/**
+ * Show replacement selection modal (pick player to transfer in)
+ */
+function showReplacementSelectionModal(playerOut, squad, bank) {
+    const allPlayers = getAllPlayers();
+    const maxBudget = playerOut.now_cost + bank;
+    const squadPlayerIds = new Set(squad.map(p => p.element));
+
+    // Filter candidates
+    const candidates = allPlayers.filter(p => {
+        return p.element_type === playerOut.element_type &&
+               p.id !== playerOut.id &&
+               p.now_cost <= maxBudget &&
+               !squadPlayerIds.has(p.id);
+    });
+
+    // Sort by PPM
+    candidates.sort((a, b) => calculatePPM(b) - calculatePPM(a));
+
+    const modalHtml = `
+        <div id="player-modal" style="
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0, 0, 0, 0.7);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 1000;
+        ">
+            <div style="
+                background: var(--bg-primary);
+                border-radius: 12px;
+                padding: 2rem;
+                max-width: 900px;
+                width: 90%;
+                max-height: 80vh;
+                overflow-y: auto;
+                box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+            ">
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem;">
+                    <div>
+                        <h3 style="font-size: 1.25rem; font-weight: 700; color: var(--text-primary); margin: 0 0 0.5rem 0;">
+                            Select Replacement for ${escapeHtml(playerOut.web_name)}
+                        </h3>
+                        <p style="font-size: 0.875rem; color: var(--text-secondary); margin: 0;">
+                            Budget: £${(maxBudget / 10).toFixed(1)}m • ${candidates.length} options
+                        </p>
+                    </div>
+                    <button
+                        id="close-modal-btn"
+                        style="
+                            background: none;
+                            border: none;
+                            font-size: 1.5rem;
+                            color: var(--text-secondary);
+                            cursor: pointer;
+                        "
+                    >
+                        <i class="fas fa-times"></i>
+                    </button>
+                </div>
+
+                <div style="margin-bottom: 1rem;">
+                    <input
+                        type="text"
+                        id="player-search-input"
+                        placeholder="Search players..."
+                        style="
+                            width: 100%;
+                            padding: 0.75rem;
+                            border: 2px solid var(--border-color);
+                            border-radius: 8px;
+                            background: var(--bg-secondary);
+                            color: var(--text-primary);
+                            font-size: 1rem;
+                        "
+                    >
+                </div>
+
+                <div id="player-list" style="display: grid; gap: 0.5rem; max-height: 400px; overflow-y: auto;">
+                    ${candidates.slice(0, 50).map(player => {
+                        const priceDiff = player.now_cost - playerOut.now_cost;
+                        const diffSign = priceDiff >= 0 ? '+' : '';
+                        const diffColor = priceDiff < 0 ? '#22c55e' : '#ef4444';
+
+                        return `
+                            <button
+                                class="select-player-in-btn"
+                                data-player-id="${player.id}"
+                                data-search="${escapeHtml(player.web_name).toLowerCase()}"
+                                style="
+                                    display: flex;
+                                    justify-content: space-between;
+                                    align-items: center;
+                                    padding: 1rem;
+                                    background: var(--bg-secondary);
+                                    border: 2px solid var(--border-color);
+                                    border-radius: 8px;
+                                    cursor: pointer;
+                                    transition: all 0.2s;
+                                    text-align: left;
+                                "
+                            >
+                                <div style="flex: 1;">
+                                    <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 0.25rem;">
+                                        ${escapeHtml(player.web_name)}
+                                    </div>
+                                    <div style="font-size: 0.875rem; color: var(--text-secondary);">
+                                        ${getTeamShortName(player.team)} • ${formatCurrency(player.now_cost)} • Form: ${formatDecimal(player.form)}
+                                    </div>
+                                </div>
+                                <div style="text-align: right;">
+                                    <div style="font-size: 0.875rem; font-weight: 600; color: ${diffColor}; margin-bottom: 0.25rem;">
+                                        ${diffSign}£${Math.abs(priceDiff / 10).toFixed(1)}m
+                                    </div>
+                                    <div style="font-size: 0.875rem; color: var(--text-secondary);">
+                                        PPM: ${formatDecimal(calculatePPM(player))}
+                                    </div>
+                                </div>
+                            </button>
+                        `;
+                    }).join('')}
+                </div>
+            </div>
+        </div>
+    `;
+
+    document.body.insertAdjacentHTML('beforeend', modalHtml);
+
+    // Attach event listeners
+    document.getElementById('close-modal-btn').addEventListener('click', closePlayerModal);
+
+    // Search functionality
+    const searchInput = document.getElementById('player-search-input');
+    searchInput.addEventListener('input', e => {
+        const query = e.target.value.toLowerCase();
+        document.querySelectorAll('.select-player-in-btn').forEach(btn => {
+            const searchText = btn.dataset.search;
+            btn.style.display = searchText.includes(query) ? 'flex' : 'none';
+        });
+    });
+
+    // Select player in
+    document.querySelectorAll('.select-player-in-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const playerInId = parseInt(btn.dataset.playerId);
+            handleConfirmTransfer(transferOutPlayerId, playerInId);
+        });
+
+        btn.addEventListener('mouseenter', e => {
+            e.currentTarget.style.borderColor = 'var(--primary-color)';
+        });
+        btn.addEventListener('mouseleave', e => {
+            e.currentTarget.style.borderColor = 'var(--border-color)';
+        });
+    });
+}
+
+/**
+ * Handle confirm transfer
+ */
+function handleConfirmTransfer(playerOutId, playerInId) {
+    const activePlan = allPlans.find(p => p.id === activePlanId);
+    if (!activePlan) return;
+
+    const result = addTransfer(activePlan, activeGameweek, playerOutId, playerInId);
+
+    if (result.success) {
+        // Update plan in array
+        const planIndex = allPlans.findIndex(p => p.id === activePlanId);
+        allPlans[planIndex] = result.updatedPlan;
+
+        savePlansToStorage(allPlans);
+        closePlayerModal();
+        renderTeamBuilderContent();
+    } else {
+        alert(`Failed to add transfer: ${result.error}`);
+    }
+}
+
+/**
+ * Close player modal
+ */
+function closePlayerModal() {
+    const modal = document.getElementById('player-modal');
+    if (modal) {
+        modal.remove();
+    }
+    transferOutPlayerId = null;
+}
+
+// ============================================================================
+// EXPORTS
+// ============================================================================
+
+export { renderTeamBuilder };

--- a/frontend/src/teamBuilderHelpers.js
+++ b/frontend/src/teamBuilderHelpers.js
@@ -1,0 +1,620 @@
+// ============================================================================
+// TEAM BUILDER HELPERS MODULE
+// Core logic for transfer planning, validation, and state management
+// ============================================================================
+
+import { getAllPlayers, currentGW } from './data.js';
+import { getPositionType, calculatePPM } from './utils.js';
+import { calculateFixtureDifficulty } from './fixtures.js';
+import { analyzePlayerRisks, hasHighRisk } from './risk.js';
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const SQUAD_LIMITS = {
+    GKP: { min: 2, max: 2 },
+    DEF: { min: 3, max: 5 },
+    MID: { min: 2, max: 5 },
+    FWD: { min: 1, max: 3 }
+};
+
+const MAX_PLAYERS_PER_TEAM = 3;
+const TOTAL_SQUAD_SIZE = 15;
+const BUDGET_LIMIT = 1000; // £100.0m in tenths
+const POINTS_HIT_PER_TRANSFER = -4;
+
+// ============================================================================
+// STATE MANAGEMENT
+// ============================================================================
+
+/**
+ * Create a new empty transfer plan
+ * @param {string} name - Plan name (e.g., "Plan A")
+ * @param {Object} currentTeam - Current team data from loadMyTeam()
+ * @param {number} planningHorizon - Number of gameweeks to plan (default 3)
+ * @returns {Object} New plan object
+ */
+export function createNewPlan(name, currentTeam, planningHorizon = 3) {
+    const startGW = currentGW + 1;
+    const gameweekPlans = {};
+
+    // Initialize empty gameweek plans
+    for (let i = 0; i < planningHorizon; i++) {
+        const gw = startGW + i;
+        gameweekPlans[gw] = {
+            transfers: [], // Array of {out: playerId, in: playerId}
+            freeTransfers: i === 0 ? (currentTeam.picks.entry_history.event_transfers_cost === 0 ? 1 : 1) : 0, // Will be calculated
+            pointsHit: 0,
+            chipUsed: null // null, 'wildcard', 'freehit', etc.
+        };
+    }
+
+    return {
+        id: generatePlanId(),
+        name,
+        created: new Date().toISOString(),
+        modified: new Date().toISOString(),
+        planningHorizon,
+        startGW,
+        gameweekPlans,
+        currentTeamSnapshot: {
+            picks: currentTeam.picks.picks.map(p => ({ ...p })),
+            bank: currentTeam.picks.entry_history.bank,
+            value: currentTeam.picks.entry_history.value
+        }
+    };
+}
+
+/**
+ * Generate a unique plan ID
+ */
+function generatePlanId() {
+    return `plan_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+}
+
+/**
+ * Calculate projected squad after applying transfers up to a specific gameweek
+ * @param {Object} plan - Transfer plan
+ * @param {number} targetGW - Calculate squad after this GW's transfers
+ * @returns {Object} { squad: Array, bank: number, value: number }
+ */
+export function calculateProjectedSquad(plan, targetGW) {
+    let squad = [...plan.currentTeamSnapshot.picks];
+    let bank = plan.currentTeamSnapshot.bank;
+
+    // Apply transfers from startGW to targetGW
+    const startGW = plan.startGW;
+    for (let gw = startGW; gw <= targetGW; gw++) {
+        const gwPlan = plan.gameweekPlans[gw];
+        if (!gwPlan) continue;
+
+        gwPlan.transfers.forEach(transfer => {
+            // Remove player out
+            const outIdx = squad.findIndex(p => p.element === transfer.out);
+            if (outIdx >= 0) {
+                squad.splice(outIdx, 1);
+            }
+
+            // Add player in
+            const playerIn = getAllPlayers().find(p => p.id === transfer.in);
+            if (playerIn) {
+                squad.push({
+                    element: playerIn.id,
+                    position: squad.length + 1, // Will be reordered later
+                    selling_price: playerIn.now_cost, // Use current price as purchase price
+                    multiplier: 1,
+                    is_captain: false,
+                    is_vice_captain: false
+                });
+
+                // Update bank
+                const playerOut = getAllPlayers().find(p => p.id === transfer.out);
+                if (playerOut) {
+                    bank += playerOut.now_cost; // Add back selling price
+                }
+                bank -= playerIn.now_cost; // Deduct purchase price
+            }
+        });
+    }
+
+    // Calculate total value
+    const squadValue = squad.reduce((sum, pick) => {
+        const player = getAllPlayers().find(p => p.id === pick.element);
+        return sum + (player ? player.now_cost : 0);
+    }, 0);
+
+    return {
+        squad,
+        bank,
+        value: squadValue
+    };
+}
+
+/**
+ * Add a transfer to a gameweek plan
+ * @param {Object} plan - Transfer plan
+ * @param {number} gameweek - Target gameweek
+ * @param {number} playerOutId - Player to transfer out
+ * @param {number} playerInId - Player to transfer in
+ * @returns {Object} { success: boolean, error?: string, updatedPlan: Object }
+ */
+export function addTransfer(plan, gameweek, playerOutId, playerInId) {
+    const gwPlan = plan.gameweekPlans[gameweek];
+    if (!gwPlan) {
+        return { success: false, error: 'Invalid gameweek' };
+    }
+
+    // Check if player out is already being transferred
+    const existingTransferOut = gwPlan.transfers.find(t => t.out === playerOutId);
+    if (existingTransferOut) {
+        return { success: false, error: 'Player already being transferred out this gameweek' };
+    }
+
+    // Check if player in is already being transferred in
+    const existingTransferIn = gwPlan.transfers.find(t => t.in === playerInId);
+    if (existingTransferIn) {
+        return { success: false, error: 'Player already being transferred in this gameweek' };
+    }
+
+    // Get projected squad BEFORE this transfer
+    const prevGW = gameweek - 1;
+    const projected = calculateProjectedSquad(plan, prevGW);
+
+    // Check if player out is in the squad
+    const hasPlayerOut = projected.squad.find(p => p.element === playerOutId);
+    if (!hasPlayerOut) {
+        return { success: false, error: 'Player not in squad' };
+    }
+
+    // Get player objects
+    const playerOut = getAllPlayers().find(p => p.id === playerOutId);
+    const playerIn = getAllPlayers().find(p => p.id === playerInId);
+
+    if (!playerOut || !playerIn) {
+        return { success: false, error: 'Invalid player selection' };
+    }
+
+    // Check budget
+    const newBank = projected.bank + playerOut.now_cost - playerIn.now_cost;
+    if (newBank < 0) {
+        const shortfall = Math.abs(newBank) / 10;
+        return { success: false, error: `Insufficient funds (short £${shortfall.toFixed(1)}m)` };
+    }
+
+    // Check position match
+    if (playerOut.element_type !== playerIn.element_type) {
+        return { success: false, error: 'Players must be in same position' };
+    }
+
+    // Add transfer
+    const updatedPlan = { ...plan };
+    updatedPlan.gameweekPlans[gameweek].transfers.push({
+        out: playerOutId,
+        in: playerInId,
+        timestamp: new Date().toISOString()
+    });
+
+    // Recalculate free transfers and points hit for all GWs
+    recalculateTransferCosts(updatedPlan);
+
+    // Validate the new squad
+    const validation = validateSquad(updatedPlan, gameweek);
+    if (!validation.valid) {
+        return { success: false, error: validation.errors[0] };
+    }
+
+    updatedPlan.modified = new Date().toISOString();
+
+    return { success: true, updatedPlan };
+}
+
+/**
+ * Remove a transfer from a gameweek plan
+ * @param {Object} plan - Transfer plan
+ * @param {number} gameweek - Target gameweek
+ * @param {number} transferIndex - Index of transfer to remove
+ * @returns {Object} Updated plan
+ */
+export function removeTransfer(plan, gameweek, transferIndex) {
+    const updatedPlan = { ...plan };
+    updatedPlan.gameweekPlans[gameweek].transfers.splice(transferIndex, 1);
+
+    // Recalculate costs
+    recalculateTransferCosts(updatedPlan);
+
+    updatedPlan.modified = new Date().toISOString();
+    return updatedPlan;
+}
+
+/**
+ * Recalculate free transfers and points hit for all gameweeks in plan
+ * @param {Object} plan - Transfer plan (mutated in place)
+ */
+function recalculateTransferCosts(plan) {
+    let freeTransfersAvailable = 1; // Start with 1 FT
+
+    const gameweeks = Object.keys(plan.gameweekPlans).sort((a, b) => a - b);
+
+    gameweeks.forEach(gw => {
+        const gwPlan = plan.gameweekPlans[gw];
+        const transferCount = gwPlan.transfers.length;
+
+        // Check if chip is active (Wildcard or Free Hit = unlimited free transfers)
+        if (gwPlan.chipUsed === 'wildcard' || gwPlan.chipUsed === 'freehit') {
+            gwPlan.freeTransfers = transferCount;
+            gwPlan.pointsHit = 0;
+            freeTransfersAvailable = 1; // Reset to 1 FT for next GW
+            return;
+        }
+
+        // Normal transfer logic
+        gwPlan.freeTransfers = Math.min(freeTransfersAvailable, transferCount);
+
+        const extraTransfers = Math.max(0, transferCount - freeTransfersAvailable);
+        gwPlan.pointsHit = extraTransfers * POINTS_HIT_PER_TRANSFER;
+
+        // Calculate FT for next week
+        if (transferCount === 0) {
+            // Banked - can have max 2 FT
+            freeTransfersAvailable = Math.min(2, freeTransfersAvailable + 1);
+        } else {
+            // Used at least 1 transfer - reset to 1 FT for next week
+            freeTransfersAvailable = 1;
+        }
+    });
+}
+
+/**
+ * Set chip for a gameweek
+ * @param {Object} plan - Transfer plan
+ * @param {number} gameweek - Target gameweek
+ * @param {string|null} chipName - 'wildcard', 'freehit', 'benchboost', 'triplecaptain', or null
+ * @param {Array} usedChips - Array of already used chips from team data
+ * @returns {Object} { success: boolean, error?: string, updatedPlan?: Object }
+ */
+export function setChip(plan, gameweek, chipName, usedChips = []) {
+    // Check if chip already used
+    if (chipName && usedChips.some(c => c.name === chipName)) {
+        return { success: false, error: `${chipName} has already been used this season` };
+    }
+
+    // Check if chip used in another GW of this plan
+    const chipUsedElsewhere = Object.entries(plan.gameweekPlans).find(
+        ([gw, gwPlan]) => gw != gameweek && gwPlan.chipUsed === chipName
+    );
+    if (chipUsedElsewhere && chipName) {
+        return { success: false, error: `${chipName} already planned for GW${chipUsedElsewhere[0]}` };
+    }
+
+    const updatedPlan = { ...plan };
+    updatedPlan.gameweekPlans[gameweek].chipUsed = chipName;
+
+    // Recalculate costs (Wildcard/Free Hit affect transfer costs)
+    recalculateTransferCosts(updatedPlan);
+
+    updatedPlan.modified = new Date().toISOString();
+
+    return { success: true, updatedPlan };
+}
+
+// ============================================================================
+// VALIDATION
+// ============================================================================
+
+/**
+ * Validate squad composition after transfers
+ * @param {Object} plan - Transfer plan
+ * @param {number} gameweek - Gameweek to validate
+ * @returns {Object} { valid: boolean, errors: Array, warnings: Array }
+ */
+export function validateSquad(plan, gameweek) {
+    const { squad, bank, value } = calculateProjectedSquad(plan, gameweek);
+    const errors = [];
+    const warnings = [];
+
+    // Check squad size
+    if (squad.length !== TOTAL_SQUAD_SIZE) {
+        errors.push(`Squad must have ${TOTAL_SQUAD_SIZE} players (currently ${squad.length})`);
+    }
+
+    // Check position counts
+    const positionCounts = { GKP: 0, DEF: 0, MID: 0, FWD: 0 };
+    squad.forEach(pick => {
+        const player = getAllPlayers().find(p => p.id === pick.element);
+        if (player) {
+            const pos = getPositionType(player);
+            positionCounts[pos]++;
+        }
+    });
+
+    Object.entries(SQUAD_LIMITS).forEach(([pos, limits]) => {
+        const count = positionCounts[pos];
+        if (count < limits.min) {
+            errors.push(`Need at least ${limits.min} ${pos} (have ${count})`);
+        }
+        if (count > limits.max) {
+            errors.push(`Maximum ${limits.max} ${pos} allowed (have ${count})`);
+        }
+    });
+
+    // Check max players per team
+    const teamCounts = {};
+    squad.forEach(pick => {
+        const player = getAllPlayers().find(p => p.id === pick.element);
+        if (player) {
+            teamCounts[player.team] = (teamCounts[player.team] || 0) + 1;
+        }
+    });
+
+    Object.entries(teamCounts).forEach(([team, count]) => {
+        if (count > MAX_PLAYERS_PER_TEAM) {
+            const player = getAllPlayers().find(p => p.team === parseInt(team));
+            errors.push(`Max ${MAX_PLAYERS_PER_TEAM} players from ${player?.team_name || 'one team'} (have ${count})`);
+        }
+    });
+
+    // Check budget
+    if (value + bank > BUDGET_LIMIT) {
+        errors.push(`Total value exceeds £100.0m`);
+    }
+
+    if (bank < 0) {
+        errors.push(`Insufficient funds (£${Math.abs(bank / 10).toFixed(1)}m over budget)`);
+    }
+
+    // Warning: Low bank balance
+    if (bank < 5 && bank >= 0) {
+        warnings.push(`Low remaining budget (£${(bank / 10).toFixed(1)}m)`);
+    }
+
+    return {
+        valid: errors.length === 0,
+        errors,
+        warnings
+    };
+}
+
+// ============================================================================
+// AUTO-SUGGESTION
+// ============================================================================
+
+/**
+ * Find suggested transfers for a gameweek
+ * @param {Object} plan - Transfer plan
+ * @param {number} gameweek - Target gameweek
+ * @param {number} maxSuggestions - Maximum number of suggestions (default 5)
+ * @returns {Array} Array of suggestions { type, priority, playerOut, playerIn, reason }
+ */
+export function findSuggestedTransfers(plan, gameweek, maxSuggestions = 5) {
+    const { squad, bank } = calculateProjectedSquad(plan, gameweek - 1);
+    const allPlayers = getAllPlayers();
+    const suggestions = [];
+
+    // 1. Problem players (injuries, suspensions, rotation risk)
+    squad.forEach(pick => {
+        const player = allPlayers.find(p => p.id === pick.element);
+        if (!player) return;
+
+        const risks = analyzePlayerRisks(player);
+        if (hasHighRisk(risks)) {
+            // Find replacements
+            const replacements = findBestReplacements(player, squad, bank, 3);
+            replacements.forEach((rep, idx) => {
+                suggestions.push({
+                    type: 'problem',
+                    priority: idx === 0 ? 'high' : 'medium',
+                    playerOut: player,
+                    playerIn: rep.player,
+                    reason: `${player.web_name} has ${risks.map(r => r.type).join(', ')}`,
+                    score: rep.score
+                });
+            });
+        }
+    });
+
+    // 2. Fixture-based upgrades
+    squad.forEach(pick => {
+        const player = allPlayers.find(p => p.id === pick.element);
+        if (!player) return;
+
+        const fdr = calculateFixtureDifficulty(player.team, 5);
+        if (fdr >= 4.0) {
+            // Poor fixtures - suggest better options
+            const replacements = findBestReplacements(player, squad, bank, 2);
+            replacements.forEach(rep => {
+                const repFdr = calculateFixtureDifficulty(rep.player.team, 5);
+                if (repFdr < fdr - 0.5) {
+                    suggestions.push({
+                        type: 'fixtures',
+                        priority: 'medium',
+                        playerOut: player,
+                        playerIn: rep.player,
+                        reason: `${player.web_name} has tough fixtures (FDR ${fdr.toFixed(1)})`,
+                        score: rep.score
+                    });
+                }
+            });
+        }
+    });
+
+    // 3. Value upgrades (better form/PPM)
+    squad.forEach(pick => {
+        const player = allPlayers.find(p => p.id === pick.element);
+        if (!player) return;
+
+        const playerPPM = calculatePPM(player);
+        const playerForm = parseFloat(player.form) || 0;
+
+        // Look for significantly better value options
+        const replacements = findBestReplacements(player, squad, bank, 2);
+        replacements.forEach(rep => {
+            const repPPM = calculatePPM(rep.player);
+            const repForm = parseFloat(rep.player.form) || 0;
+
+            // Only suggest if significantly better (20% PPM improvement or 2+ form difference)
+            if (repPPM > playerPPM * 1.2 || repForm > playerForm + 2) {
+                suggestions.push({
+                    type: 'upgrade',
+                    priority: 'low',
+                    playerOut: player,
+                    playerIn: rep.player,
+                    reason: `${rep.player.web_name} has better value (PPM ${repPPM.toFixed(1)} vs ${playerPPM.toFixed(1)})`,
+                    score: rep.score
+                });
+            }
+        });
+    });
+
+    // Sort by priority and score
+    const priorityOrder = { high: 3, medium: 2, low: 1 };
+    suggestions.sort((a, b) => {
+        const priorityDiff = priorityOrder[b.priority] - priorityOrder[a.priority];
+        if (priorityDiff !== 0) return priorityDiff;
+        return b.score - a.score;
+    });
+
+    // Remove duplicates (same player out)
+    const seen = new Set();
+    const uniqueSuggestions = suggestions.filter(s => {
+        const key = `${s.playerOut.id}_${s.playerIn.id}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+    });
+
+    return uniqueSuggestions.slice(0, maxSuggestions);
+}
+
+/**
+ * Find best replacement candidates for a player
+ * @param {Object} player - Player to replace
+ * @param {Array} currentSquad - Current squad picks
+ * @param {number} bank - Available bank
+ * @param {number} limit - Max replacements to return
+ * @returns {Array} Array of { player, score, priceDiff }
+ */
+function findBestReplacements(player, currentSquad, bank, limit = 5) {
+    const allPlayers = getAllPlayers();
+    const maxBudget = player.now_cost + bank;
+    const squadPlayerIds = new Set(currentSquad.map(p => p.element));
+
+    // Filter candidates
+    const candidates = allPlayers.filter(p => {
+        return p.element_type === player.element_type &&
+               p.id !== player.id &&
+               p.now_cost <= maxBudget &&
+               !squadPlayerIds.has(p.id) &&
+               p.status !== 'u' && // Not unavailable
+               p.chance_of_playing_next_round !== 0; // Not ruled out
+    });
+
+    // Score each candidate
+    const scored = candidates.map(c => ({
+        player: c,
+        score: scoreReplacement(c),
+        priceDiff: c.now_cost - player.now_cost
+    }));
+
+    // Sort by score
+    scored.sort((a, b) => b.score - a.score);
+
+    return scored.slice(0, limit);
+}
+
+/**
+ * Score a replacement candidate
+ * @param {Object} player - Player to score
+ * @returns {number} Score (0-100)
+ */
+function scoreReplacement(player) {
+    let score = 0;
+
+    // Form (0-30)
+    const form = parseFloat(player.form) || 0;
+    score += Math.min(30, form * 5);
+
+    // Fixtures (0-25)
+    const fdr = calculateFixtureDifficulty(player.team, 5);
+    score += Math.max(0, (5 - fdr) * 5);
+
+    // PPM (0-20)
+    const ppm = calculatePPM(player);
+    score += Math.min(20, ppm * 10);
+
+    // Minutes (0-15)
+    const minutesPct = (player.minutes || 0) / (38 * 90) * 100;
+    score += Math.min(15, minutesPct / 6.67);
+
+    // Transfer momentum (0-10)
+    let netTransfers = 0;
+    if (player.github_transfers) {
+        netTransfers = player.github_transfers.transfers_in - player.github_transfers.transfers_out;
+    } else if (player.transfers_in_event !== undefined) {
+        netTransfers = player.transfers_in_event - player.transfers_out_event;
+    }
+    score += Math.min(10, Math.max(0, netTransfers / 10000));
+
+    return score;
+}
+
+// ============================================================================
+// LOCALSTORAGE PERSISTENCE
+// ============================================================================
+
+const STORAGE_KEY = 'fplanner_transfer_plans';
+
+/**
+ * Save plans to localStorage
+ * @param {Array} plans - Array of plan objects
+ */
+export function savePlansToStorage(plans) {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(plans));
+        console.log(`💾 Saved ${plans.length} plan(s) to localStorage`);
+    } catch (err) {
+        console.error('❌ Failed to save plans:', err);
+    }
+}
+
+/**
+ * Load plans from localStorage
+ * @returns {Array} Array of plan objects
+ */
+export function loadPlansFromStorage() {
+    try {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (!stored) return [];
+
+        const plans = JSON.parse(stored);
+        console.log(`📂 Loaded ${plans.length} plan(s) from localStorage`);
+        return plans;
+    } catch (err) {
+        console.error('❌ Failed to load plans:', err);
+        return [];
+    }
+}
+
+/**
+ * Delete a plan from storage
+ * @param {string} planId - Plan ID to delete
+ */
+export function deletePlanFromStorage(planId) {
+    const plans = loadPlansFromStorage();
+    const filtered = plans.filter(p => p.id !== planId);
+    savePlansToStorage(filtered);
+    console.log(`🗑️ Deleted plan ${planId}`);
+}
+
+/**
+ * Get available chips for team
+ * @param {Object} teamData - Team data from loadMyTeam()
+ * @returns {Array} Array of available chip names
+ */
+export function getAvailableChips(teamData) {
+    const allChips = ['wildcard', 'freehit', 'benchboost', 'triplecaptain'];
+    const usedChips = teamData.team.chips || [];
+    const usedChipNames = usedChips.map(c => c.name);
+
+    return allChips.filter(chip => !usedChipNames.includes(chip));
+}


### PR DESCRIPTION
Implements comprehensive Team Builder page with:

Core Features:
- Multi-gameweek transfer planning (3-8 GWs configurable)
- Free transfer tracking with rollover logic
- Points hit calculation (-4 per extra transfer)
- Budget validation and tracking
- Squad composition validation (positions, team limits)

UI Components:
- Multiple plan management with tabs (Plan A, B, C, etc.)
- Gameweek tabs showing transfer counts and chips
- Transfer summary cards (planned transfers, points hit, budget, validation)
- Projected squad view with risk indicators
- Player selection modal with search functionality

Auto-Suggestions:
- Problem players (injuries, suspensions, rotation risk)
- Fixture-based upgrades (poor fixture runs)
- Value upgrades (better form/PPM)
- Priority-based ranking (high/medium/low)

Chips Support:
- Wildcard and Free Hit (unlimited transfers)
- Bench Boost and Triple Captain
- Chip availability tracking from FPL API
- Prevents duplicate chip usage

Data Persistence:
- localStorage for multiple saved plans
- Auto-save on all changes
- Plan metadata (created, modified timestamps)

Files Added:
- frontend/src/teamBuilderHelpers.js - Core logic, validation, suggestions
- frontend/src/renderTeamBuilder.js - UI rendering and event handling

Files Modified:
- frontend/src/main.js - Added Team Builder navigation and route