### PR TITLE
fix: improve Points vs Price zone rendering with z-index and opacity

### DIFF
--- a/frontend/src/renderCharts.js
+++ b/frontend/src/renderCharts.js
@@ -428,17 +428,18 @@ async function renderPointsPriceChart() {
         data: positions[pos].data
     }));
 
-    // Add value zones as a separate series for consistent rendering
-    series.push({
+    // Add value zones FIRST as a separate series for proper rendering
+    series.unshift({
         name: 'Value Zones',
         type: 'scatter',
         silent: true,
         symbolSize: 0,
         itemStyle: { opacity: 0 },
         data: [],
+        z: -1,
         markArea: {
             silent: true,
-            itemStyle: { opacity: 0.08 },
+            itemStyle: { opacity: 0.15 },
             data: [
                 [
                     {
@@ -621,7 +622,9 @@ async function renderPointsPriceChart() {
                     type: 'dashed',
                     opacity: 0.3
                 }
-            }
+            },
+            min: 0,
+            max: 300
         },
         series: series
     };


### PR DESCRIPTION
- Move zone series to front of array using unshift() instead of push()
- Add z: -1 to ensure zones render behind data points
- Increase zone opacity from 0.08 to 0.15 for better visibility
- Add explicit yAxis bounds (min: 0, max: 300) to ensure zones are visible
- Zones should now render properly: green (Value), blue (Premium), red (Trap)