### PR TITLE
feat: dynamic zones for Points vs Price and fix position filter bug

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -277,10 +277,17 @@ async function initializeApp() {
 
         // Parse URL hash for initial page
         const hash = window.location.hash.slice(1); // Remove #
-        const [page, subTab] = hash.split('/');
-        
+        const [page, subTab, position] = hash.split('/');
+
         if (page) {
-            navigate(page, subTab || 'overview');
+            if (page === 'data-analysis' && position) {
+                currentPage = page;
+                currentSubTab = subTab || 'overview';
+                updateNavigation();
+                renderDataAnalysis(subTab || 'overview', position);
+            } else {
+                navigate(page, subTab || 'overview');
+            }
         } else {
             navigate('my-team');
         }
@@ -525,10 +532,15 @@ if (document.readyState === 'loading') {
 // Handle browser back/forward
 window.addEventListener('hashchange', () => {
     const hash = window.location.hash.slice(1);
-    const [page, subTab] = hash.split('/');
+    const [page, subTab, position] = hash.split('/');
     if (page) {
         currentPage = page;
         currentSubTab = subTab || 'overview';
-        renderPage();
+        updateNavigation();
+        if (page === 'data-analysis' && position) {
+            renderDataAnalysis(subTab || 'overview', position);
+        } else {
+            renderPage();
+        }
     }
 });

--- a/frontend/src/renderCharts.js
+++ b/frontend/src/renderCharts.js
@@ -373,6 +373,15 @@ async function renderPointsPriceChart() {
         }
     });
 
+    // Calculate dynamic zone boundaries based on actual data
+    const allPoints = players.map(p => p.total_points || 0);
+    const maxPoints = Math.max(...allPoints, 50); // At least 50 to avoid very small charts
+    const yAxisMax = Math.ceil((maxPoints + 25) / 10) * 10; // Round up to nearest 10
+
+    // Define zone boundaries dynamically
+    // High points threshold = 60% of max points (above this = Value/Premium zones)
+    const highPointsThreshold = Math.round(maxPoints * 0.6);
+
     // Create series
     const series = Object.keys(positions).map(pos => ({
         name: positions[pos].name,
@@ -445,7 +454,7 @@ async function renderPointsPriceChart() {
                     {
                         name: 'Value Zone',
                         xAxis: 3,
-                        yAxis: 120,
+                        yAxis: highPointsThreshold,
                         itemStyle: { color: '#10b981' },
                         label: {
                             show: true,
@@ -458,13 +467,13 @@ async function renderPointsPriceChart() {
                             borderRadius: 4
                         }
                     },
-                    { xAxis: 8.5, yAxis: 300 }
+                    { xAxis: 8.5, yAxis: yAxisMax }
                 ],
                 [
                     {
                         name: 'Premium Zone',
                         xAxis: 8.5,
-                        yAxis: 120,
+                        yAxis: highPointsThreshold,
                         itemStyle: { color: '#3b82f6' },
                         label: {
                             show: true,
@@ -477,7 +486,7 @@ async function renderPointsPriceChart() {
                             borderRadius: 4
                         }
                     },
-                    { xAxis: 15, yAxis: 300 }
+                    { xAxis: 15, yAxis: yAxisMax }
                 ],
                 [
                     {
@@ -496,7 +505,7 @@ async function renderPointsPriceChart() {
                             borderRadius: 4
                         }
                     },
-                    { xAxis: 15, yAxis: 120 }
+                    { xAxis: 15, yAxis: highPointsThreshold }
                 ]
             ]
         }
@@ -624,7 +633,7 @@ async function renderPointsPriceChart() {
                 }
             },
             min: 0,
-            max: 300
+            max: yAxisMax
         },
         series: series
     };


### PR DESCRIPTION
Points vs Price improvements:
- Calculate zone boundaries dynamically based on actual max points
- Set high points threshold at 60% of max points
- Y-axis max adjusts to maxPoints + 25 (rounded to nearest 10)
- Zones now scale with season progress (early vs late season)

Data Analysis position filter fix:
- Fix double-click bug where clicking position filter reset to 'all' first
- Root cause: hashchange event was only parsing first 2 hash segments
- Now correctly parses all 3 segments: page/subTab/position
- Position filter now works on first click as expected