### PR TITLE
refactor: update Team Analysis to focus on fixture difficulty and sim…

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -957,9 +957,9 @@ OUTPUT FORMAT (MUST be valid JSON):
     "insight 3 about players to avoid or transfer out"
   ],
   "Team Analysis": [
-    "insight 1 about optimal team structure and budget allocation",
-    "insight 2 about position-specific trends (GKP/DEF/MID/FWD)",
-    "insight 3 about chip strategy or captaincy recommendations"
+    "insight 1 about teams with the best fixtures in the next 5 gameweeks",
+    "insight 2 about teams to avoid due to tough upcoming fixtures",
+    "insight 3 about fixture swings or teams entering/exiting good runs"
   ]
 }
 

--- a/frontend/src/renderDataAnalysis.js
+++ b/frontend/src/renderDataAnalysis.js
@@ -27,7 +27,9 @@ import {
 
 import {
     getFixtures,
-    calculateFixtureDifficulty
+    calculateFixtureDifficulty,
+    getTeamsWithBestFixtures,
+    getTeamsWithWorstFixtures
 } from './fixtures.js';
 
 import {
@@ -1236,16 +1238,9 @@ async function loadAIInsightsForTab(tab, position) {
             points: p.total_points
         }));
 
-    // 5. Team Analysis: Position distribution and budget data
-    const positionCounts = {};
-    const positionAvgPPM = {};
-    ['GKP', 'DEF', 'MID', 'FWD'].forEach(pos => {
-        const posMap = { 'GKP': 1, 'DEF': 2, 'MID': 3, 'FWD': 4 };
-        const posPlayers = players.filter(p => p.element_type === posMap[pos]);
-        positionCounts[pos] = posPlayers.length;
-        const avgPPM = posPlayers.reduce((sum, p) => sum + calculatePPM(p), 0) / posPlayers.length || 0;
-        positionAvgPPM[pos] = avgPPM.toFixed(2);
-    });
+    // 5. Team Analysis: Teams with best/worst fixtures in next 5 games
+    const teamsWithBestFixtures = getTeamsWithBestFixtures(10, 5);
+    const teamsWithWorstFixtures = getTeamsWithWorstFixtures(10, 5);
 
     const contextData = {
         overview: {
@@ -1257,8 +1252,8 @@ async function loadAIInsightsForTab(tab, position) {
         differentials,
         transferTargets,
         teamAnalysis: {
-            positionCounts,
-            positionAvgPPM,
+            bestFixtures: teamsWithBestFixtures,
+            worstFixtures: teamsWithWorstFixtures,
             currentGW
         }
     };

--- a/frontend/src/renderInsightBanner.js
+++ b/frontend/src/renderInsightBanner.js
@@ -190,7 +190,6 @@ export function renderInsightBanner(insights, contextId) {
     }
 
     const timestamp = new Date(insights.timestamp).toLocaleTimeString();
-    const gwText = insights.gameweek ? ` FOR GW ${insights.gameweek}` : '';
 
     const categories = ['Overview', 'Hidden Gems', 'Differentials', 'Transfer Targets', 'Team Analysis'];
 
@@ -211,7 +210,7 @@ export function renderInsightBanner(insights, contextId) {
                     font-size: 1rem;
                     margin: 0 0 1rem 0;
                 ">
-                    🤖 AI INSIGHTS${gwText}
+                    AI Insights
                 </h3>
 
                 <!-- Tab Navigation -->


### PR DESCRIPTION
…plify header

Changes:
- Update Team Analysis prompt to focus on teams with best/worst fixtures
- Send actual fixture difficulty data for top 10 teams (best/worst)
- Simplify banner header from '🤖 AI INSIGHTS FOR GW X' to 'AI Insights'
- Import getTeamsWithBestFixtures and getTeamsWithWorstFixtures functions