### PR TITLE
fix: remove pull-to-refresh, add rate limiting, and fix iOS safe area

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -202,9 +202,10 @@ body {
     margin: 1rem auto !important;
   }
 
-  /* Compact header on mobile */
+  /* Compact header on mobile with safe area support */
   nav {
     padding: 0.75rem 1rem !important;
+    padding-top: calc(0.75rem + env(safe-area-inset-top)) !important;
   }
 
   nav h1 {


### PR DESCRIPTION
Critical Fixes:
1. Removed pull-to-refresh gesture (too sensitive, caused rate limiting)
2. Added 30-second cooldown between manual refreshes
3. Fixed iOS Safari PWA top cutoff with safe-area-inset-top
4. Improved error messages for rate limit warnings

Rate Limit Protection:
- Minimum 30 seconds between refresh requests
- Stores last refresh timestamp in localStorage
- Shows countdown if user tries to refresh too soon
- User-friendly error: "Please wait Xs before refreshing"
- Prevents accidental spam that triggers backend rate limit

iOS PWA Fix:
- Added safe-area-inset-top to nav element
- Prevents header from being cut off by notch/status bar
- Works on iPhone models with notch and Dynamic Island

Refresh UX:
- Manual button only (no pull gesture)
- Clear success/error toasts
- Shows specific error messages (rate limit, network, etc.)
- Disabled state while refreshing
- Spinning icon during refresh

Bundle Size Impact:
- Before: 15.22 kB gzipped
- After: 14.49 kB gzipped (-0.73 kB)
- Removed pull-to-refresh initialization code

User Experience:
- No more accidental refreshes
- Protected from rate limiting
- Works properly on iOS Safari PWA
- Better error communication