### PR TITLE
fix: remove My Team header/tabs on mobile and fix sticky positioning

### DIFF
--- a/frontend/src/renderMyTeam.js
+++ b/frontend/src/renderMyTeam.js
@@ -271,100 +271,110 @@ export function renderMyTeam(teamData, subTab = 'overview') {
         }
     }
 
-    // Render tab navigation
-    const tabHTML = `
-        <div style="margin-bottom: 2rem;">
-            <h1 style="font-size: 2rem; font-weight: 700; color: var(--primary-color); margin-bottom: 1rem;">
-                <i class="fas fa-users"></i> My Team
-            </h1>
+    // Check if mobile layout
+    const useMobile = shouldUseMobileLayout();
 
-            <!-- Main Tabs -->
-            <div style="display: flex; gap: 0.5rem; border-bottom: 2px solid var(--border-color); margin-bottom: 1rem;">
-                <button
-                    class="my-team-tab-btn"
-                    data-tab="overview"
-                    style="
-                        padding: 0.75rem 1.5rem;
-                        background: ${subTab === 'overview' ? 'var(--primary-color)' : 'transparent'};
-                        color: ${subTab === 'overview' ? 'white' : 'var(--text-primary)'};
-                        border: none;
-                        border-bottom: 3px solid ${subTab === 'overview' ? 'var(--primary-color)' : 'transparent'};
-                        cursor: pointer;
-                        font-weight: 600;
-                        transition: all 0.2s;
-                    "
-                >
-                    <i class="fas fa-users"></i> Team Overview
-                </button>
-                <button
-                    class="my-team-tab-btn"
-                    data-tab="leagues"
-                    style="
-                        padding: 0.75rem 1.5rem;
-                        background: ${subTab === 'leagues' ? 'var(--primary-color)' : 'transparent'};
-                        color: ${subTab === 'leagues' ? 'white' : 'var(--text-primary)'};
-                        border: none;
-                        border-bottom: 3px solid ${subTab === 'leagues' ? 'var(--primary-color)' : 'transparent'};
-                        cursor: pointer;
-                        font-weight: 600;
-                        transition: all 0.2s;
-                    "
-                >
-                    <i class="fas fa-trophy"></i> My Leagues
-                </button>
-            </div>
-
-            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;">
-                <button
-                    id="change-team-btn"
-                    style="
-                        padding: 8px 16px;
-                        border-radius: 20px;
-                        background: var(--bg-secondary);
-                        color: var(--text-secondary);
-                        border: 1px solid var(--border-color);
-                        font-size: 14px;
-                        font-weight: 500;
-                        cursor: pointer;
-                        transition: all 0.2s ease;
-                    "
-                >
-                    <i class="fas fa-arrow-left" style="margin-right: 6px;"></i>Change Team
-                </button>
-
-                <button
-                    id="refresh-team-btn"
-                    class="hide-desktop touch-target"
-                    style="
-                        padding: 8px 16px;
-                        border-radius: 20px;
-                        background: var(--secondary-color);
-                        color: var(--primary-color);
-                        border: none;
-                        font-size: 14px;
-                        font-weight: 600;
-                        cursor: pointer;
-                        transition: all 0.2s ease;
-                        display: flex;
-                        align-items: center;
-                        gap: 6px;
-                    "
-                >
-                    <i class="fas fa-sync-alt"></i>Refresh
-                </button>
-            </div>
-        </div>
-    `;
-
-    // Render content based on current tab
+    // Render content based on layout
     let contentHTML = '';
-    if (subTab === 'overview') {
+    if (useMobile) {
+        // Mobile: Skip header/tabs, go straight to compact view
         contentHTML = renderTeamOverviewTab(teamData);
-    } else if (subTab === 'leagues') {
-        contentHTML = renderLeaguesTab(teamData);
-    }
+        container.innerHTML = contentHTML;
+    } else {
+        // Desktop: Show header and tabs
+        const tabHTML = `
+            <div style="margin-bottom: 2rem;">
+                <h1 style="font-size: 2rem; font-weight: 700; color: var(--primary-color); margin-bottom: 1rem;">
+                    <i class="fas fa-users"></i> My Team
+                </h1>
 
-    container.innerHTML = tabHTML + contentHTML;
+                <!-- Main Tabs -->
+                <div style="display: flex; gap: 0.5rem; border-bottom: 2px solid var(--border-color); margin-bottom: 1rem;">
+                    <button
+                        class="my-team-tab-btn"
+                        data-tab="overview"
+                        style="
+                            padding: 0.75rem 1.5rem;
+                            background: ${subTab === 'overview' ? 'var(--primary-color)' : 'transparent'};
+                            color: ${subTab === 'overview' ? 'white' : 'var(--text-primary)'};
+                            border: none;
+                            border-bottom: 3px solid ${subTab === 'overview' ? 'var(--primary-color)' : 'transparent'};
+                            cursor: pointer;
+                            font-weight: 600;
+                            transition: all 0.2s;
+                        "
+                    >
+                        <i class="fas fa-users"></i> Team Overview
+                    </button>
+                    <button
+                        class="my-team-tab-btn"
+                        data-tab="leagues"
+                        style="
+                            padding: 0.75rem 1.5rem;
+                            background: ${subTab === 'leagues' ? 'var(--primary-color)' : 'transparent'};
+                            color: ${subTab === 'leagues' ? 'white' : 'var(--text-primary)'};
+                            border: none;
+                            border-bottom: 3px solid ${subTab === 'leagues' ? 'var(--primary-color)' : 'transparent'};
+                            cursor: pointer;
+                            font-weight: 600;
+                            transition: all 0.2s;
+                        "
+                    >
+                        <i class="fas fa-trophy"></i> My Leagues
+                    </button>
+                </div>
+
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;">
+                    <button
+                        id="change-team-btn"
+                        style="
+                            padding: 8px 16px;
+                            border-radius: 20px;
+                            background: var(--bg-secondary);
+                            color: var(--text-secondary);
+                            border: 1px solid var(--border-color);
+                            font-size: 14px;
+                            font-weight: 500;
+                            cursor: pointer;
+                            transition: all 0.2s ease;
+                        "
+                    >
+                        <i class="fas fa-arrow-left" style="margin-right: 6px;"></i>Change Team
+                    </button>
+
+                    <button
+                        id="refresh-team-btn"
+                        class="hide-desktop touch-target"
+                        style="
+                            padding: 8px 16px;
+                            border-radius: 20px;
+                            background: var(--secondary-color);
+                            color: var(--primary-color);
+                            border: none;
+                            font-size: 14px;
+                            font-weight: 600;
+                            cursor: pointer;
+                            transition: all 0.2s ease;
+                            display: flex;
+                            align-items: center;
+                            gap: 6px;
+                        "
+                    >
+                        <i class="fas fa-sync-alt"></i>Refresh
+                    </button>
+                </div>
+            </div>
+        `;
+
+        // Render content based on current tab
+        if (subTab === 'overview') {
+            contentHTML = renderTeamOverviewTab(teamData);
+        } else if (subTab === 'leagues') {
+            contentHTML = renderLeaguesTab(teamData);
+        }
+
+        container.innerHTML = tabHTML + contentHTML;
+    }
     attachRiskTooltipListeners();
 
     // Add tab click event listeners

--- a/frontend/src/renderMyTeamCompact.js
+++ b/frontend/src/renderMyTeamCompact.js
@@ -48,10 +48,11 @@ export function renderCompactHeader(teamData, gwNumber) {
     return `
         <div style="
             position: sticky;
-            top: calc(env(safe-area-inset-top) + 3.5rem);
+            top: 0;
             background: var(--bg-primary);
             z-index: 100;
             padding: 0.5rem 1rem;
+            padding-top: calc(0.5rem + env(safe-area-inset-top));
             border-bottom: 2px solid var(--border-color);
             margin: -1rem -1rem 0.75rem -1rem;
         ">
@@ -229,7 +230,7 @@ export function renderCompactTeamList(players, gwNumber, templatePlayerIds = new
             font-weight: 700;
             text-transform: uppercase;
             position: sticky;
-            top: calc(env(safe-area-inset-top) + 7rem);
+            top: calc(4.5rem + env(safe-area-inset-top));
             z-index: 90;
         ">
             <div>Pos</div>


### PR DESCRIPTION
- Mobile now skips header and tabs, goes straight to compact team view
- Compact header sticks at top: 0 with safe-area-inset padding
- Table header sticks at 4.5rem below compact header
- Desktop layout unchanged (still shows header and tabs)

This creates maximum real estate for the team table on mobile.