### PR TITLE
fix: remove gap between PWA header and content on mobile

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -199,7 +199,8 @@ body {
   /* Make main content full width on mobile */
   #app-container {
     padding: 1rem !important;
-    margin: 1rem auto !important;
+    padding-top: 0 !important;
+    margin: 0 auto 1rem auto !important;
   }
 
   /* Compact header on mobile with safe area support */


### PR DESCRIPTION
- Removed top padding and margin from #app-container on mobile
- Content now sits flush against PWA nav header
- Maintains side and bottom padding for proper spacing