### PR TITLE
fix: correct PWA header positioning and bottom nav padding

### DIFF
--- a/frontend/src/mobileNav.js
+++ b/frontend/src/mobileNav.js
@@ -21,7 +21,7 @@ export function createMobileNav(currentPage, onNavigate) {
     const navHtml = `
         <nav
             id="mobile-bottom-nav"
-            class="hide-desktop bottom-nav"
+            class="hide-desktop"
             style="
                 position: fixed;
                 bottom: 0;
@@ -33,7 +33,7 @@ export function createMobileNav(currentPage, onNavigate) {
                 justify-content: space-around;
                 align-items: center;
                 padding: 0.5rem 0;
-                padding-bottom: calc(0.5rem + env(safe-area-inset-bottom));
+                padding-bottom: max(0.5rem, env(safe-area-inset-bottom));
                 box-shadow: 0 -2px 10px var(--shadow);
                 z-index: 1000;
             "

--- a/frontend/src/renderMyTeamCompact.js
+++ b/frontend/src/renderMyTeamCompact.js
@@ -66,11 +66,10 @@ export function renderCompactHeader(teamData, gwNumber) {
             id="compact-header"
             style="
                 position: sticky;
-                top: 0;
+                top: calc(3.5rem + env(safe-area-inset-top));
                 background: var(--bg-primary);
                 z-index: 100;
                 padding: 0.75rem 1rem;
-                padding-top: calc(0.75rem + env(safe-area-inset-top));
                 border-bottom: 2px solid var(--border-color);
                 margin: -1rem -1rem 0 -1rem;
             "
@@ -279,7 +278,7 @@ export function renderCompactTeamList(players, gwNumber, templatePlayerIds = new
             font-weight: 700;
             text-transform: uppercase;
             position: sticky;
-            top: calc(10rem + env(safe-area-inset-top));
+            top: calc(9rem + env(safe-area-inset-top));
             z-index: 90;
         ">
             <div>Player</div>


### PR DESCRIPTION
Fixed three layout issues:
1. PWA header no longer cut off - compact header now sticky at calc(3.5rem + safe-area-inset-top) to sit below PWA nav
2. Removed gap between PWA header and content - removed duplicate safe-area-inset-top padding from compact header
3. Fixed excessive bottom nav padding - changed from calc(0.5rem + safe-area-inset-bottom) to max(0.5rem, safe-area-inset-bottom) to prevent double padding

Table header also adjusted to calc(9rem + safe-area-inset-top) to account for new compact header position.