### PR TITLE
fix: use correct team.summary_* fields for header data

### DIFF
--- a/frontend/src/renderMyTeam.js
+++ b/frontend/src/renderMyTeam.js
@@ -1732,10 +1732,12 @@ function renderManagerInfo(teamData) {
     const { team, picks } = teamData;
     const entry = picks.entry_history;
 
-    // Handle optional fields safely
-    const overallRank = team.summary_overall_rank || team.current_event_points || 0;
+    // Use team.summary_* fields (most accurate, from /api/entry/{teamId}/)
+    const overallRank = team.summary_overall_rank || 0;
     const totalPlayers = team.last_deadline_total_players || team.total_players || 0;
-    const overallPoints = team.summary_overall_points || team.overall_points || 0;
+    const overallPoints = team.summary_overall_points || 0;
+    const gwPoints = team.summary_event_points || 0;
+    const gwRank = team.summary_event_rank || 0;
 
     return `
         <div style="
@@ -1759,7 +1761,7 @@ function renderManagerInfo(teamData) {
                 <div>
                     <div style="font-size: 0.875rem; opacity: 0.9; margin-bottom: 0.25rem;">Total Points</div>
                     <div style="font-size: 1.5rem; font-weight: 700;">${overallPoints.toLocaleString()}</div>
-                    <div style="font-size: 0.875rem; opacity: 0.8; margin-top: 0.25rem;">GW${teamData.gameweek}: ${entry.total_points} pts</div>
+                    <div style="font-size: 0.875rem; opacity: 0.8; margin-top: 0.25rem;">GW${teamData.gameweek}: ${gwPoints} pts (Rank: ${gwRank.toLocaleString()})</div>
                 </div>
                 <div>
                     <div style="font-size: 0.875rem; opacity: 0.9; margin-bottom: 0.25rem;">Team Value</div>

--- a/frontend/src/renderMyTeamCompact.js
+++ b/frontend/src/renderMyTeamCompact.js
@@ -39,9 +39,13 @@ export function renderCompactHeader(teamData, gwNumber) {
     const { picks, team } = teamData;
     const entry = picks.entry_history;
 
-    const gwPoints = entry.event_points || 0;
-    const totalPoints = entry.total_points || 0;
-    const overallRank = entry.overall_rank ? entry.overall_rank.toLocaleString() : 'N/A';
+    // Use team.summary_* fields (most accurate, from /api/entry/{teamId}/)
+    const gwPoints = team.summary_event_points || 0;
+    const totalPoints = team.summary_overall_points || 0;
+    const overallRank = team.summary_overall_rank ? team.summary_overall_rank.toLocaleString() : 'N/A';
+    const gwRank = team.summary_event_rank ? team.summary_event_rank.toLocaleString() : 'N/A';
+
+    // Team value and bank from entry_history (GW-specific)
     const teamValue = ((entry.value || 0) / 10).toFixed(1);
     const bank = ((entry.bank || 0) / 10).toFixed(1);
     const freeTransfers = entry.event_transfers || 0;


### PR DESCRIPTION
Fixed both mobile and desktop to use accurate data from team object:

Mobile (renderMyTeamCompact.js):
- GW Points: team.summary_event_points (was entry.event_points - wrong)
- Total Points: team.summary_overall_points (was entry.total_points - wrong)
- Overall Rank: team.summary_overall_rank (was entry.overall_rank - inconsistent)
- Added: team.summary_event_rank for GW rank

Desktop (renderMyTeam.js):
- Fixed GW points display: was showing entry.total_points (cumulative), now shows team.summary_event_points (correct GW points)
- Added GW rank alongside GW points
- Cleaned up fallbacks (removed incorrect team.current_event_points fallback)

All fields now sourced from /api/entry/{teamId}/ (team.summary_*) which is the authoritative source for season-long stats.