### PR TITLE
fix: mobile UI improvements - refresh button, nav bar, container flus…

### DIFF
--- a/frontend/src/mobileNav.js
+++ b/frontend/src/mobileNav.js
@@ -40,9 +40,11 @@ export function createMobileNav(currentPage, onNavigate) {
             "
         >
             ${navItems.map(item => {
-                // FPL green color for Refresh button
-                const iconColor = item.isGreen ? '#00ff87' : (item.disabled ? 'rgba(255,255,255,0.4)' : 'white');
-                const textColor = item.disabled ? 'rgba(255,255,255,0.4)' : 'white';
+                // FPL green background with purple text for Refresh button
+                const isRefresh = item.isGreen;
+                const buttonBg = isRefresh ? '#00ff87' : (currentPage === item.id ? 'rgba(255,255,255,0.15)' : 'transparent');
+                const iconColor = isRefresh ? '#37003c' : (item.disabled ? 'rgba(255,255,255,0.4)' : 'white');
+                const textColor = isRefresh ? '#37003c' : (item.disabled ? 'rgba(255,255,255,0.4)' : 'white');
 
                 return `
                 <button
@@ -55,7 +57,7 @@ export function createMobileNav(currentPage, onNavigate) {
                         flex-direction: column;
                         align-items: center;
                         gap: 0.15rem;
-                        background: ${currentPage === item.id ? 'rgba(255,255,255,0.15)' : 'transparent'};
+                        background: ${buttonBg};
                         border: none;
                         padding: 0.3rem 0.35rem;
                         border-radius: 0.4rem;
@@ -169,7 +171,8 @@ export function initMobileNav(navigateCallback) {
             if (!item.disabled) {
                 const page = item.dataset.page;
                 const currentPage = getCurrentPage();
-                item.style.background = currentPage === page ? 'rgba(255,255,255,0.15)' : 'transparent';
+                const isRefresh = item.dataset.action === 'refresh';
+                item.style.background = isRefresh ? '#00ff87' : (currentPage === page ? 'rgba(255,255,255,0.15)' : 'transparent');
             }
         });
     });
@@ -187,8 +190,9 @@ export function updateMobileNav(activePage) {
     mobileNavItems.forEach(item => {
         const page = item.dataset.page;
         const isActive = page === activePage;
+        const isRefresh = item.dataset.action === 'refresh';
 
-        item.style.background = isActive ? 'rgba(255,255,255,0.15)' : 'transparent';
+        item.style.background = isRefresh ? '#00ff87' : (isActive ? 'rgba(255,255,255,0.15)' : 'transparent');
         const label = item.querySelector('span');
         if (label) {
             label.style.fontWeight = isActive ? '700' : '500';
@@ -205,11 +209,12 @@ function addMainContentPadding() {
     style.textContent = `
         @media (max-width: 767px) {
             #app-container {
-                padding-bottom: calc(5rem + env(safe-area-inset-bottom)) !important;
+                padding-bottom: calc(4rem + env(safe-area-inset-bottom)) !important;
             }
 
             body {
-                padding-bottom: env(safe-area-inset-bottom);
+                padding-bottom: 0;
+                margin-bottom: 0;
             }
         }
     `;

--- a/frontend/src/renderMyTeamCompact.js
+++ b/frontend/src/renderMyTeamCompact.js
@@ -88,7 +88,7 @@ export function renderCompactHeader(teamData, gwNumber) {
         const captainPlayer = getPlayerById(captainPick.element);
         if (captainPlayer) {
             const captainOpp = getGWOpponent(captainPlayer.team, gwNumber);
-            const oppBadge = `<span class="${getDifficultyClass(captainOpp.difficulty)}" style="padding: 0.15rem 0.3rem; border-radius: 0.25rem; font-weight: 600; font-size: 0.7rem;">${captainOpp.name} (${captainOpp.isHome ? 'H' : 'A'})</span>`;
+            const oppBadge = `<span class="${getDifficultyClass(captainOpp.difficulty)}" style="padding: 0.1rem 0.25rem; border-radius: 0.2rem; font-weight: 600; font-size: 0.65rem;">${captainOpp.name} (${captainOpp.isHome ? 'H' : 'A'})</span>`;
             captainInfo = `${captainPlayer.web_name} vs. ${oppBadge}`;
         }
     }
@@ -97,7 +97,7 @@ export function renderCompactHeader(teamData, gwNumber) {
         const vicePlayer = getPlayerById(vicePick.element);
         if (vicePlayer) {
             const viceOpp = getGWOpponent(vicePlayer.team, gwNumber);
-            const oppBadge = `<span class="${getDifficultyClass(viceOpp.difficulty)}" style="padding: 0.15rem 0.3rem; border-radius: 0.25rem; font-weight: 600; font-size: 0.7rem;">${viceOpp.name} (${viceOpp.isHome ? 'H' : 'A'})</span>`;
+            const oppBadge = `<span class="${getDifficultyClass(viceOpp.difficulty)}" style="padding: 0.1rem 0.25rem; border-radius: 0.2rem; font-weight: 600; font-size: 0.65rem;">${viceOpp.name} (${viceOpp.isHome ? 'H' : 'A'})</span>`;
             viceInfo = `${vicePlayer.web_name} vs. ${oppBadge}`;
         }
     }
@@ -138,7 +138,7 @@ export function renderCompactHeader(teamData, gwNumber) {
                 z-index: 100;
                 padding: 0.5rem 0.75rem;
                 border-bottom: 2px solid var(--border-color);
-                margin: -0.5rem -1rem 0 -1rem;
+                margin: 0;
             "
         >
             <div style="display: flex; justify-content: space-between; align-items: flex-start; gap: 0.75rem;">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -198,9 +198,9 @@ body {
 
   /* Make main content full width on mobile */
   #app-container {
-    padding: 0.5rem !important;
+    padding: 0 !important;
     padding-top: 0 !important;
-    padding-bottom: 2rem !important; /* Space for bottom nav */
+    padding-bottom: 0 !important;
     margin: 0 auto !important;
   }
 


### PR DESCRIPTION
…h, pill sizes

- Refresh button now has FPL green background (#00ff87) with purple text (#37003c)
- Nav bar properly flushed to bottom of screen, removed footer gap
- Container flushed to screen edges (removed all padding)
- Standardized opponent pill sizes to match table styling (0.65rem font, 0.1rem/0.25rem padding)
- Updated header margins to work with edge-to-edge container