### PR TITLE
fix: increase bottom padding to 4.5rem to prevent nav bar overlap

### DIFF
--- a/frontend/src/mobileNav.js
+++ b/frontend/src/mobileNav.js
@@ -221,8 +221,7 @@ function addMainContentPadding() {
     style.textContent = `
         @media (max-width: 767px) {
             #app-container {
-                /* Reduced from 5rem to 3.5rem to fix overlap while maintaining safe space */
-                padding-bottom: calc(3.5rem + env(safe-area-inset-bottom)) !important;
+                padding-bottom: calc(4.5rem + env(safe-area-inset-bottom)) !important;
             }
 
             body {


### PR DESCRIPTION
- Updated padding from 3.5rem to 4.5rem
- Fixes purple bleed/overlap issue above navigation bar
- Ensures proper spacing between content and bottom nav