### PR TITLE
fix: improve nav bar spacing and standardize opponent pill widths

### DIFF
--- a/frontend/src/mobileNav.js
+++ b/frontend/src/mobileNav.js
@@ -32,9 +32,9 @@ export function createMobileNav(currentPage, onNavigate) {
                 background: #37003c;
                 border-top: 1px solid rgba(255,255,255,0.1);
                 display: flex;
-                justify-content: space-around;
+                justify-content: space-between;
                 align-items: center;
-                padding: 0.25rem 0;
+                padding: 0.25rem 0.5rem;
                 padding-bottom: max(0.25rem, env(safe-area-inset-bottom));
                 z-index: 1000;
             "

--- a/frontend/src/renderMyTeam.js
+++ b/frontend/src/renderMyTeam.js
@@ -1932,7 +1932,7 @@ function renderTeamRows(players, gameweek, next5GWs) {
                 </td>
                 <td style="padding: 0.75rem 0.5rem;">${getTeamShortName(player.team)}</td>
                 <td style="padding: 0.75rem 0.5rem; text-align: center;">
-                    <span class="${getDifficultyClass(gwOpp.difficulty)}" style="padding: 0.25rem 0.5rem; border-radius: 0.25rem; font-weight: 600; font-size: 0.75rem;">
+                    <span class="${getDifficultyClass(gwOpp.difficulty)}" style="padding: 0.25rem 0.5rem; border-radius: 0.25rem; font-weight: 600; font-size: 0.75rem; min-width: 5rem; display: inline-block; text-align: center;">
                         ${gwOpp.name}${gwOpp.isHome ? ' (H)' : ' (A)'}
                     </span>
                 </td>

--- a/frontend/src/renderMyTeamCompact.js
+++ b/frontend/src/renderMyTeamCompact.js
@@ -88,7 +88,7 @@ export function renderCompactHeader(teamData, gwNumber) {
         const captainPlayer = getPlayerById(captainPick.element);
         if (captainPlayer) {
             const captainOpp = getGWOpponent(captainPlayer.team, gwNumber);
-            const oppBadge = `<span class="${getDifficultyClass(captainOpp.difficulty)}" style="padding: 0.1rem 0.25rem; border-radius: 0.2rem; font-weight: 600; font-size: 0.65rem;">${captainOpp.name} (${captainOpp.isHome ? 'H' : 'A'})</span>`;
+            const oppBadge = `<span class="${getDifficultyClass(captainOpp.difficulty)}" style="padding: 0.1rem 0.25rem; border-radius: 0.2rem; font-weight: 600; font-size: 0.65rem; min-width: 3.5rem; display: inline-block; text-align: center;">${captainOpp.name} (${captainOpp.isHome ? 'H' : 'A'})</span>`;
             captainInfo = `${captainPlayer.web_name} vs. ${oppBadge}`;
         }
     }
@@ -97,7 +97,7 @@ export function renderCompactHeader(teamData, gwNumber) {
         const vicePlayer = getPlayerById(vicePick.element);
         if (vicePlayer) {
             const viceOpp = getGWOpponent(vicePlayer.team, gwNumber);
-            const oppBadge = `<span class="${getDifficultyClass(viceOpp.difficulty)}" style="padding: 0.1rem 0.25rem; border-radius: 0.2rem; font-weight: 600; font-size: 0.65rem;">${viceOpp.name} (${viceOpp.isHome ? 'H' : 'A'})</span>`;
+            const oppBadge = `<span class="${getDifficultyClass(viceOpp.difficulty)}" style="padding: 0.1rem 0.25rem; border-radius: 0.2rem; font-weight: 600; font-size: 0.65rem; min-width: 3.5rem; display: inline-block; text-align: center;">${viceOpp.name} (${viceOpp.isHome ? 'H' : 'A'})</span>`;
             viceInfo = `${vicePlayer.web_name} vs. ${oppBadge}`;
         }
     }
@@ -266,7 +266,7 @@ export function renderCompactPlayerRow(pick, player, gwNumber, isInTemplate) {
                 ${hasHighSeverity ? '<i class="fas fa-exclamation-triangle" style="color: var(--danger-color); font-size: 0.65rem; margin-left: 0.2rem;"></i>' : ''}
             </div>
             <div style="text-align: center;">
-                <span class="${getDifficultyClass(gwOpp.difficulty)}" style="padding: 0.05rem 0.25rem; border-radius: 0.2rem; font-weight: 600; font-size: 0.65rem;">
+                <span class="${getDifficultyClass(gwOpp.difficulty)}" style="padding: 0.05rem 0.25rem; border-radius: 0.2rem; font-weight: 600; font-size: 0.65rem; min-width: 3.5rem; display: inline-block; text-align: center;">
                     ${gwOpp.name} (${gwOpp.isHome ? 'H' : 'A'})
                 </span>
             </div>


### PR DESCRIPTION
- Changed nav bar justify-content from space-around to space-between
- Added horizontal padding (0.5rem) to nav bar for better button distribution
- Standardized opponent pill widths with min-width (3.5rem mobile, 5rem desktop)
- Added display: inline-block and text-align: center to all opponent badges
- Applies to both mobile and desktop views