### PR TITLE
fix: spread nav bar buttons to edges and extend purple header to top

### DIFF
--- a/frontend/src/mobileNav.js
+++ b/frontend/src/mobileNav.js
@@ -34,7 +34,7 @@ export function createMobileNav(currentPage, onNavigate) {
                 display: flex;
                 justify-content: space-between;
                 align-items: center;
-                padding: 0.25rem 0.5rem;
+                padding: 0.25rem 0;
                 padding-bottom: max(0.25rem, env(safe-area-inset-bottom));
                 z-index: 1000;
             "

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -208,6 +208,17 @@ body {
   nav {
     padding: 0.75rem 1rem !important;
     padding-top: calc(0.75rem + env(safe-area-inset-top)) !important;
+    margin-top: calc(-1 * env(safe-area-inset-top)) !important;
+  }
+
+  /* Extend purple background to top of screen */
+  body {
+    background: var(--primary-color) !important;
+    padding-top: env(safe-area-inset-top);
+  }
+
+  #app-container {
+    background: var(--bg-primary);
   }
 
   nav h1 {


### PR DESCRIPTION
- Removed horizontal padding from nav bar so buttons touch screen edges
- Added negative margin-top to nav to extend to very top of screen
- Set body background to purple on mobile to fill top safe area
- Set app-container background to match page background
- Ensures seamless purple header from top of screen to nav bar