### PR TITLE
fix: resolve league button not working on PWA/mobile

### DIFF
--- a/frontend/src/mobileNav.js
+++ b/frontend/src/mobileNav.js
@@ -118,7 +118,7 @@ export function initMobileNav(navigateCallback) {
             if (action === 'league') {
                 console.log('🏆 League button clicked');
                 // Get team ID from window or localStorage
-                const teamId = window.currentTeamId || localStorage.getItem('teamId');
+                const teamId = window.currentTeamId || localStorage.getItem('fplanner_team_id');
                 console.log('Team ID:', teamId);
 
                 if (teamId) {

--- a/frontend/src/renderMyTeam.js
+++ b/frontend/src/renderMyTeam.js
@@ -106,6 +106,7 @@ export function renderMyTeamForm() {
         setTimeout(() => {
             loadMyTeam(cachedTeamId)
                 .then(teamData => {
+                    window.currentTeamId = cachedTeamId; // Expose globally for mobile nav
                     renderMyTeam(teamData);
                 })
                 .catch(err => {
@@ -244,6 +245,9 @@ async function handleTeamRefresh() {
 
     console.log('✅ Team data refreshed');
 }
+
+// Expose handleTeamRefresh globally for mobile nav and other components
+window.handleTeamRefresh = handleTeamRefresh;
 
 /**
  * Render My Team page with loaded data
@@ -1995,6 +1999,7 @@ window.loadAndRenderTeam = async function() {
 
         // CACHE TEAM ID ← ADD THIS
         localStorage.setItem('fplanner_team_id', teamId);
+        window.currentTeamId = teamId; // Expose globally for mobile nav
 
         renderMyTeam(teamData);
     } catch (err) {


### PR DESCRIPTION
Fixed three critical issues preventing the league button from working:

1. Corrected localStorage key from 'teamId' to 'fplanner_team_id' in mobileNav.js
   - The button was failing to retrieve the team ID due to wrong key name

2. Exposed handleTeamRefresh function globally via window object
   - Mobile nav and league selector can now trigger team refresh after league selection

3. Set window.currentTeamId when team data is loaded
   - Provides fallback team ID access for mobile components
   - Set during both manual load and auto-load from cache

These fixes ensure the league button works properly on PWA installations and mobile devices.