### PR TITLE
feat: improve PWA mobile nav layout and implement soft night mode

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -248,17 +248,17 @@ function updateCountdown() {
 }
 
 /**
- * Load saved theme preference
+ * Load saved theme preference (defaults to dark mode)
  */
 function loadTheme() {
-    const savedTheme = localStorage.getItem('theme') || 'light';
+    const savedTheme = localStorage.getItem('theme') || 'dark';
     document.documentElement.setAttribute('data-theme', savedTheme);
-    
+
     const button = document.getElementById('theme-toggle');
     if (savedTheme === 'dark') {
         button.innerHTML = '<i class="fas fa-sun"></i>';
     }
-    
+
     console.log(`🎨 Theme loaded: ${savedTheme}`);
 }
 

--- a/frontend/src/mobileNav.js
+++ b/frontend/src/mobileNav.js
@@ -29,35 +29,18 @@ export function createMobileNav(currentPage, onNavigate) {
                 bottom: 0;
                 left: 0;
                 right: 0;
-                background: #37003c;
-                border-top: 1px solid rgba(255,255,255,0.1);
+                background: var(--bg-secondary);
+                border-top: 1px solid var(--border-color);
                 display: flex;
                 justify-content: space-between;
                 align-items: center;
-                padding: 0.25rem 0;
-                padding-bottom: max(0.25rem, env(safe-area-inset-bottom));
+                padding: 0.4rem 0.5rem;
+                padding-bottom: max(0.4rem, env(safe-area-inset-bottom));
                 z-index: 1000;
+                gap: 0.25rem;
             "
         >
             ${navItems.map(item => {
-                // Determine icon and text color
-                let iconColor = 'white';
-                let textColor = 'white';
-                let itemBg = currentPage === item.id ? 'rgba(255,255,255,0.2)' : 'transparent';
-                
-                if (item.disabled) {
-                    iconColor = 'rgba(255,255,255,0.4)';
-                    textColor = 'rgba(255,255,255,0.4)';
-                } else if (item.isGreen) {
-                    // NEW STYLING: Green background with primary text/icon color for contrast
-                    iconColor = 'var(--primary-color)'; // Dark purple/primary color for icon
-                    textColor = 'var(--primary-color)'; // Dark purple/primary color for text
-                    itemBg = '#00ff87'; // FPL Green for background
-                } else if (currentPage === item.id) {
-                    // Active style for non-refresh buttons
-                    itemBg = 'rgba(255,255,255,0.2)';
-                }
-
                 return `
                 <button
                     class="mobile-nav-item no-select touch-target"
@@ -68,23 +51,25 @@ export function createMobileNav(currentPage, onNavigate) {
                         display: flex;
                         flex-direction: column;
                         align-items: center;
-                        gap: 0.15rem;
-                        background: ${item.isGreen ? '#00ff87' : (currentPage === item.id ? 'rgba(255,255,255,0.15)' : 'transparent')};
+                        justify-content: center;
+                        gap: 0.25rem;
+                        background: ${item.isGreen ? 'var(--secondary-color)' : (currentPage === item.id ? 'var(--bg-tertiary)' : 'transparent')};
                         border: none;
-                        padding: 0.3rem 0.35rem;
-                        border-radius: 0.4rem;
-                        color: ${item.isGreen ? '#37003c' : (item.disabled ? 'rgba(255,255,255,0.4)' : 'white')};
+                        padding: 0.5rem 0.4rem;
+                        border-radius: 0.5rem;
+                        color: ${item.isGreen ? 'var(--bg-primary)' : (item.disabled ? 'var(--text-tertiary)' : 'var(--text-primary)')};
                         cursor: ${item.disabled ? 'not-allowed' : 'pointer'};
                         transition: all 0.2s;
                         flex: 1;
-                        max-width: 70px;
+                        min-height: 60px;
                         opacity: ${item.disabled ? '0.5' : '1'};
                     "
                 >
-                    <i class="fas ${item.icon}" style="font-size: 1.1rem; color: ${item.isGreen ? '#37003c' : (item.disabled ? 'rgba(255,255,255,0.4)' : 'white')};"></i>
+                    <i class="fas ${item.icon}" style="font-size: 1.3rem;"></i>
                     <span style="
-                        font-size: 0.65rem;
+                        font-size: 0.7rem;
                         font-weight: ${currentPage === item.id || item.isGreen ? '700' : '500'};
+                        white-space: nowrap;
                     ">${item.label}</span>
                 </button>
             `;
@@ -175,7 +160,10 @@ export function initMobileNav(navigateCallback) {
         // Add touch feedback
         item.addEventListener('touchstart', () => {
             if (!item.disabled) {
-                item.style.background = 'rgba(255,255,255,0.25)';
+                const isRefresh = item.dataset.action === 'refresh';
+                if (!isRefresh) {
+                    item.style.background = 'var(--border-dark)';
+                }
             }
         });
 
@@ -184,7 +172,7 @@ export function initMobileNav(navigateCallback) {
                 const page = item.dataset.page;
                 const currentPage = getCurrentPage();
                 const isRefresh = item.dataset.action === 'refresh';
-                item.style.background = isRefresh ? '#00ff87' : (currentPage === page ? 'rgba(255,255,255,0.15)' : 'transparent');
+                item.style.background = isRefresh ? 'var(--secondary-color)' : (currentPage === page ? 'var(--bg-tertiary)' : 'transparent');
             }
         });
     });
@@ -204,7 +192,7 @@ export function updateMobileNav(activePage) {
         const isActive = page === activePage;
         const isRefresh = item.dataset.action === 'refresh';
 
-        item.style.background = isRefresh ? '#00ff87' : (isActive ? 'rgba(255,255,255,0.15)' : 'transparent');
+        item.style.background = isRefresh ? 'var(--secondary-color)' : (isActive ? 'var(--bg-tertiary)' : 'transparent');
         const label = item.querySelector('span');
         if (label) {
             label.style.fontWeight = isActive || item.dataset.action === 'refresh' ? '700' : '500';
@@ -221,7 +209,7 @@ function addMainContentPadding() {
     style.textContent = `
         @media (max-width: 767px) {
             #app-container {
-                padding-bottom: calc(4.5rem + env(safe-area-inset-bottom)) !important;
+                padding-bottom: calc(5rem + env(safe-area-inset-bottom)) !important;
             }
 
             body {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -38,38 +38,38 @@
 }
 
 [data-theme="dark"] {
-    /* Dark Mode Colors */
-    --bg-primary: #0b090b;
-    --bg-secondary: #1a181a;
-    --bg-tertiary: #252325;
-    --text-primary: #f1edf2;
-    --text-secondary: #b5b1b6;
-    --text-tertiary: #89858a;
-    --border-color: #2e2c2e;
-    --border-dark: #3f3d3f;
-    --primary-color: #37003c;
-    --primary-hover: #4a004f;
-    --secondary-color: #00ff88;
-    --secondary-hover: #00d970;
-    --accent-color: #8b2a92;
-    --shadow: rgba(0, 0, 0, 0.4);
-    
-    /* Success/Alert Colors */
-    --success-color: #00ff88;
-    --danger-color: #ef4444;
-    --warning-color: #fbbf24;
-    
+    /* Dark Mode Colors - Soft Claude-style */
+    --bg-primary: #1a1815;
+    --bg-secondary: #2a2522;
+    --bg-tertiary: #352f2c;
+    --text-primary: #d4d0c8;
+    --text-secondary: #9b968e;
+    --text-tertiary: #6e6a64;
+    --border-color: #3a3530;
+    --border-dark: #4a4540;
+    --primary-color: #4a1a4f;
+    --primary-hover: #5a2a5f;
+    --secondary-color: #00d97e;
+    --secondary-hover: #00b968;
+    --accent-color: #7a4a7f;
+    --shadow: rgba(0, 0, 0, 0.3);
+
+    /* Success/Alert Colors - Softer */
+    --success-color: #00d97e;
+    --danger-color: #e85d5d;
+    --warning-color: #f0b449;
+
     /* Soft Heatmap Colors - Dark Mode */
-    --heat-red-bg: #5c1f1f;
-    --heat-red-text: #fca5a5;
-    --heat-yellow-bg: #5c4a1f;
-    --heat-yellow-text: #fcd34d;
-    --heat-light-green-bg: #1f4d2e;
-    --heat-light-green-text: #86efac;
-    --heat-dark-green-bg: #235c3a;
-    --heat-dark-green-text: #bbf7d0;
-    --heat-gray-bg: #1a181a;
-    --heat-gray-text: #b5b1b6;
+    --heat-red-bg: #4a2828;
+    --heat-red-text: #e89999;
+    --heat-yellow-bg: #4a3f28;
+    --heat-yellow-text: #e8cf88;
+    --heat-light-green-bg: #2a4035;
+    --heat-light-green-text: #88d9a8;
+    --heat-dark-green-bg: #2e4a3a;
+    --heat-dark-green-text: #a8e8b8;
+    --heat-gray-bg: #2a2522;
+    --heat-gray-text: #9b968e;
 }
 
 /* Base styles */


### PR DESCRIPTION
Mobile Nav Improvements:
- Removed max-width constraint (was 70px) to allow buttons to spread full width
- Added horizontal padding (0.5rem) and gap (0.25rem) between buttons
- Increased button sizes: min-height 60px, larger padding (0.5rem)
- Increased icon size from 1.1rem to 1.3rem for better visibility
- Increased font size from 0.65rem to 0.7rem
- Updated bottom padding calculation from 4.5rem to 5rem to account for larger nav
- Converted all hardcoded colors to CSS variables for proper theme support

Soft Night Mode (Claude-style):
- Changed default theme from 'light' to 'dark'
- Implemented warmer, softer color palette for dark mode:
  * Backgrounds: Warm brown-grays (#1a1815, #2a2522) instead of pure black
  * Text: Soft cream (#d4d0c8) instead of bright white (#f1edf2)
  * Borders: Subtle warm tones (#3a3530) instead of harsh grays
  * Reduced overall contrast for easier on the eyes
- Updated all accent colors to softer variants
- Heatmap colors adjusted to maintain readability with reduced contrast

These changes create a more comfortable viewing experience with better use of screen real estate on mobile devices.