### PR TITLE
fix: correct league selector API endpoint

### DIFF
--- a/frontend/src/leagueSelector.js
+++ b/frontend/src/leagueSelector.js
@@ -10,7 +10,7 @@
  */
 export async function fetchUserLeagues(teamId) {
     try {
-        const response = await fetch(`/api/entry/${teamId}/`);
+        const response = await fetch(`/api/team/${teamId}`);
         if (!response.ok) {
             throw new Error('Failed to fetch team data');
         }
@@ -18,7 +18,7 @@ export async function fetchUserLeagues(teamId) {
         const data = await response.json();
 
         // Extract classic leagues only (not head-to-head)
-        const leagues = data.leagues?.classic || [];
+        const leagues = data.team?.leagues?.classic || [];
 
         // Store in localStorage for quick access
         localStorage.setItem(`fpl_leagues_${teamId}`, JSON.stringify(leagues));


### PR DESCRIPTION
Changed the fetchUserLeagues function to use the correct backend endpoint:
- Old: `/api/entry/${teamId}/` (incorrect, doesn't exist)
- New: `/api/team/${teamId}` (correct, matches backend API)

Also fixed the data path to access leagues:
- Old: `data.leagues?.classic`
- New: `data.team?.leagues?.classic`

This matches the data structure returned by the backend and ensures leagues are properly displayed in the mobile league selector modal.