### PR TITLE
feat: add league info to mobile team header and league selector dropdown

### DIFF
--- a/frontend/src/leagueInfo.js
+++ b/frontend/src/leagueInfo.js
@@ -1,0 +1,134 @@
+/**
+ * League Info Helper
+ * Handles fetching and rendering league position data for mobile compact header
+ */
+
+import { loadLeagueStandings } from './data.js';
+
+/**
+ * Load and render league info into the placeholder
+ */
+export async function loadAndRenderLeagueInfo() {
+    const placeholder = document.getElementById('league-info-placeholder');
+    if (!placeholder) return;
+
+    const teamId = parseInt(placeholder.dataset.teamId, 10);
+    const leagueId = parseInt(placeholder.dataset.leagueId, 10);
+
+    if (!teamId || !leagueId) return;
+
+    try {
+        const leagueData = await loadLeagueStandings(leagueId);
+
+        // Find user's position in standings
+        const userEntry = leagueData.standings.results.find(entry => entry.entry === teamId);
+
+        if (!userEntry) {
+            placeholder.innerHTML = `
+                <div style="font-size: 0.65rem; color: var(--text-secondary);">
+                    Not in this league
+                </div>
+            `;
+            return;
+        }
+
+        const position = userEntry.rank;
+        const totalEntries = leagueData.standings.results.length;
+        const leagueName = leagueData.league.name;
+
+        // Calculate gaps
+        const aboveEntry = leagueData.standings.results.find(e => e.rank === position - 1);
+        const belowEntry = leagueData.standings.results.find(e => e.rank === position + 1);
+
+        const gapAbove = aboveEntry ? userEntry.total - aboveEntry.total : 0;
+        const gapBelow = belowEntry ? belowEntry.total - userEntry.total : 0;
+
+        // Build gap display
+        let gapDisplay = '';
+        if (position > 1 && gapAbove < 0) {
+            gapDisplay += `<span style="color: #ef4444;">↑${Math.abs(gapAbove)}</span>`;
+        }
+        if (position < totalEntries && gapBelow > 0) {
+            if (gapDisplay) gapDisplay += ' / ';
+            gapDisplay += `<span style="color: #22c55e;">↓${gapBelow}</span>`;
+        }
+        if (!gapDisplay) {
+            gapDisplay = position === 1 ? '<span style="color: #22c55e;">1st place!</span>' : '-';
+        }
+
+        // Render league info
+        placeholder.innerHTML = `
+            <div style="font-size: 0.65rem; color: var(--text-secondary); line-height: 1.3;">
+                <div style="margin-bottom: 0.1rem; font-weight: 600; color: var(--text-primary);">
+                    ${escapeHtml(leagueName.length > 18 ? leagueName.substring(0, 18) + '...' : leagueName)}: ${position}/${totalEntries}
+                </div>
+                <div>
+                    Gap: ${gapDisplay}
+                </div>
+            </div>
+        `;
+    } catch (error) {
+        console.error('Failed to load league info:', error);
+        placeholder.innerHTML = `
+            <div style="font-size: 0.65rem; color: var(--text-secondary);">
+                Failed to load
+            </div>
+        `;
+    }
+}
+
+/**
+ * Escape HTML to prevent XSS
+ */
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+/**
+ * Initialize league selector dropdown
+ */
+export async function initializeLeagueSelector(teamId) {
+    const selector = document.getElementById('mobile-league-selector');
+    if (!selector) return;
+
+    try {
+        // Fetch team data to get leagues
+        const response = await fetch(`/api/team/${teamId}`);
+        const data = await response.json();
+        const leagues = data.team?.leagues?.classic || [];
+
+        // Get currently selected league
+        const selectedLeagueId = localStorage.getItem(`fpl_selected_league_${teamId}`);
+
+        // Populate dropdown
+        selector.innerHTML = `
+            <option value="">Select a league...</option>
+            ${leagues.map(league => `
+                <option value="${league.id}" ${selectedLeagueId == league.id ? 'selected' : ''}>
+                    ${escapeHtml(league.name)}
+                </option>
+            `).join('')}
+        `;
+
+        // Add change handler
+        selector.addEventListener('change', async (e) => {
+            const leagueId = e.target.value;
+
+            if (leagueId) {
+                localStorage.setItem(`fpl_selected_league_${teamId}`, leagueId);
+                console.log('✅ League selected:', leagueId);
+            } else {
+                localStorage.removeItem(`fpl_selected_league_${teamId}`);
+                console.log('✅ League selection cleared');
+            }
+
+            // Reload the page to update league info
+            window.location.reload();
+        });
+    } catch (error) {
+        console.error('Failed to load leagues for selector:', error);
+        selector.innerHTML = '<option value="">Failed to load leagues</option>';
+    }
+}

--- a/frontend/src/mobileNav.js
+++ b/frontend/src/mobileNav.js
@@ -3,8 +3,6 @@
  * Bottom navigation bar for mobile devices
  */
 
-import { showLeagueSelector } from './leagueSelector.js';
-
 /**
  * Create mobile bottom navigation bar
  * @param {string} currentPage - Currently active page
@@ -101,27 +99,19 @@ export function initMobileNav(navigateCallback) {
             // Handle action buttons (League, Refresh)
             const action = item.dataset.action;
             if (action === 'league') {
-                console.log('🏆 League button clicked');
-                // Get team ID from window or localStorage
-                const teamId = window.currentTeamId || localStorage.getItem('fplanner_team_id');
-                console.log('Team ID:', teamId);
+                console.log('🏆 League button clicked - navigating to leagues');
+                // Navigate to leagues page/view
+                // The league selector is now in the compact header, so the button should navigate
+                const page = 'my-team'; // Could create dedicated league page later
+                navigateCallback(page);
 
-                if (teamId) {
-                    console.log('Opening league selector...');
-                    try {
-                        showLeagueSelector(parseInt(teamId, 10), (leagueId) => {
-                            console.log('✅ League selected:', leagueId);
-                            // Trigger refresh to update template players
-                            if (window.handleTeamRefresh) {
-                                window.handleTeamRefresh();
-                            }
-                        });
-                    } catch (error) {
-                        console.error('❌ Error opening league selector:', error);
+                // Scroll to league info if available
+                setTimeout(() => {
+                    const leagueInfo = document.getElementById('league-info-placeholder');
+                    if (leagueInfo) {
+                        leagueInfo.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
                     }
-                } else {
-                    console.error('❌ No team ID found');
-                }
+                }, 300);
                 return;
             }
             if (action === 'refresh') {

--- a/frontend/src/renderMyTeam.js
+++ b/frontend/src/renderMyTeam.js
@@ -10,6 +10,11 @@ import {
 } from './data.js';
 
 import {
+    loadAndRenderLeagueInfo,
+    initializeLeagueSelector
+} from './leagueInfo.js';
+
+import {
     getPositionShort,
     getPositionType,
     formatCurrency,
@@ -403,6 +408,14 @@ export function renderMyTeam(teamData, subTab = 'overview') {
             e.target.style.background = 'var(--bg-secondary)';
             e.target.style.color = 'var(--text-secondary)';
             e.target.style.borderColor = 'var(--border-color)';
+        });
+    }
+
+    // Initialize league selector and league info for mobile
+    if (useMobile) {
+        requestAnimationFrame(async () => {
+            await initializeLeagueSelector(teamData.team.id);
+            await loadAndRenderLeagueInfo();
         });
     }
 

--- a/frontend/src/renderMyTeamCompact.js
+++ b/frontend/src/renderMyTeamCompact.js
@@ -35,7 +35,7 @@ import {
 /**
  * Render ultra-compact header with team info and GW card
  */
-export function renderCompactHeader(teamData, gwNumber) {
+export async function renderCompactHeader(teamData, gwNumber) {
     const { picks, team } = teamData;
     const entry = picks.entry_history;
 
@@ -102,32 +102,40 @@ export function renderCompactHeader(teamData, gwNumber) {
         }
     }
 
-    // Calculate GW card color based on rank performance (relative to overall rank)
-    let gwCardBg = 'var(--bg-secondary)';
-    let gwCardColor = 'var(--text-primary)';
+    // Calculate GW text color based on rank performance (relative to overall rank)
+    let gwTextColor = 'var(--text-primary)';
 
     if (overallRankNum > 0 && gwRankNum > 0) {
         const rankRatio = gwRankNum / overallRankNum;
 
         if (rankRatio <= 0.5) {
             // Exceptional: GW rank is 50% or better than overall rank
-            gwCardBg = 'rgba(147, 51, 234, 0.15)'; // Purple
-            gwCardColor = '#9333ea';
+            gwTextColor = '#9333ea'; // Purple
         } else if (rankRatio < 1.0) {
             // Outperforming: GW rank is better than overall rank
-            gwCardBg = 'rgba(34, 197, 94, 0.15)'; // Green
-            gwCardColor = '#22c55e';
+            gwTextColor = '#22c55e'; // Green
         } else if (rankRatio <= 1.2) {
             // On par: Within 20% of overall rank
-            gwCardBg = 'rgba(234, 179, 8, 0.15)'; // Yellow
-            gwCardColor = '#eab308';
+            gwTextColor = '#eab308'; // Yellow
         } else {
             // Underperforming: Worse than 20% of overall rank
-            gwCardBg = 'rgba(239, 68, 68, 0.15)'; // Red
-            gwCardColor = '#ef4444';
+            gwTextColor = '#ef4444'; // Red
         }
     }
-    
+
+    // Get selected league info
+    const selectedLeagueId = localStorage.getItem(`fpl_selected_league_${team.id}`);
+    let leagueInfo = '';
+
+    if (selectedLeagueId && selectedLeagueId !== 'null') {
+        // Store league data in a data attribute for later rendering
+        leagueInfo = `
+            <div id="league-info-placeholder" data-team-id="${team.id}" data-league-id="${selectedLeagueId}" style="margin-top: 0.35rem; padding-top: 0.35rem; border-top: 1px solid var(--border-color);">
+                <div style="font-size: 0.65rem; color: var(--text-secondary);">Loading league...</div>
+            </div>
+        `;
+    }
+
     // --- FIX: Add CSS variable to dynamically set header height
     const headerHeightStyle = `--compact-header-height: calc(3.5rem + 8rem + env(safe-area-inset-top));`;
 
@@ -190,23 +198,39 @@ export function renderCompactHeader(teamData, gwNumber) {
                     <div style="font-size: 0.7rem; color: var(--text-secondary);">
                         GW Vice Captain: ${viceInfo}
                     </div>
+
+                    <!-- League Selector Dropdown -->
+                    <div id="league-selector-dropdown" style="margin-top: 0.3rem;">
+                        <select
+                            id="mobile-league-selector"
+                            style="
+                                width: 100%;
+                                padding: 0.3rem 0.5rem;
+                                font-size: 0.7rem;
+                                background: var(--bg-secondary);
+                                border: 1px solid var(--border-color);
+                                border-radius: 0.3rem;
+                                color: var(--text-primary);
+                                cursor: pointer;
+                            "
+                        >
+                            <option value="">Loading leagues...</option>
+                        </select>
+                    </div>
                 </div>
 
                 <div style="
-                    background: ${gwCardBg};
-                    border: 1px solid ${gwCardColor}; /* Decreased from 2px */
-                    border-radius: 6px; /* Slightly reduced */
-                    padding: 0.3rem 0.5rem; /* Decreased from 0.5rem 0.75rem */
-                    text-align: center;
-                    min-width: 70px; /* Reduced from 85px */
+                    background: var(--bg-secondary);
+                    border: 1px solid var(--border-color);
+                    border-radius: 6px;
+                    padding: 0.4rem 0.5rem;
+                    min-width: 90px;
                     flex-shrink: 0;
                 ">
-                    <div style="font-size: 1.25rem; font-weight: 700; color: ${gwCardColor}; line-height: 1;">
-                        ${gwPoints}
+                    <div style="font-size: 1rem; font-weight: 700; color: ${gwTextColor}; line-height: 1.2;">
+                        GW${gwNumber}: ${gwPoints}
                     </div>
-                    <div style="font-size: 0.6rem; color: var(--text-secondary); margin-top: 0.15rem;">
-                        GW${gwNumber}
-                    </div>
+                    ${leagueInfo}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Mobile Team Header Enhancements:
- Enhanced top-right GW card to show "GW11: 52 pts" format with colored text
  * Text color based on GW rank performance (purple/green/yellow/red)
  * Removed background color - now uses subtle border instead
- Added league info section below GW points showing:
  * League name and position (e.g., "Work League: 3/156")
  * Point gaps to next above (red) and below (green)
  * Auto-loads when league is selected

League Selector:
- Added dropdown below Vice Captain info for easy league selection
- Persists selection in localStorage
- Reloads page on change to update league info

League Button Behavior:
- Changed from opening modal to scrolling to league info
- Removed dependency on league selector modal
- Better UX for quick league viewing

New Files:
- leagueInfo.js: Helper module for fetching and rendering league data
  * Fetches league standings from API
  * Calculates position and point gaps
  * Populates league selector dropdown

This provides a more compact, information-dense mobile experience with league context always visible at the top of the team page.