### PR TITLE
fix: remove async from renderCompactHeader to prevent [object Promise…

### DIFF
--- a/frontend/src/renderMyTeamCompact.js
+++ b/frontend/src/renderMyTeamCompact.js
@@ -35,7 +35,7 @@ import {
 /**
  * Render ultra-compact header with team info and GW card
  */
-export async function renderCompactHeader(teamData, gwNumber) {
+export function renderCompactHeader(teamData, gwNumber) {
     const { picks, team } = teamData;
     const entry = picks.entry_history;
 


### PR DESCRIPTION
…] display

The renderCompactHeader function was marked as async but was being used in a template literal without await, causing it to return a Promise object that rendered as '[object Promise]' instead of the HTML string.

Changed back to synchronous function. League info still loads asynchronously via loadAndRenderLeagueInfo() after DOM rendering.