### PR TITLE
fix: resolve mobile nav highlighting, remove redundant selector, fix …

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -64,8 +64,8 @@ function updateNavLinks() {
         }
     });
 
-    // Update mobile navigation as well
-    updateMobileNav(currentPage);
+    // Update mobile navigation as well (pass subTab for proper highlighting)
+    updateMobileNav(currentPage, currentSubTab);
 }
 
 /**

--- a/frontend/src/mobileNav.js
+++ b/frontend/src/mobileNav.js
@@ -164,18 +164,30 @@ export function initMobileNav(navigateCallback) {
 /**
  * Update mobile navigation active state
  * @param {string} activePage - The currently active page
+ * @param {string} subTab - Optional subtab for pages with tabs
  */
-export function updateMobileNav(activePage) {
+export function updateMobileNav(activePage, subTab = 'overview') {
     const mobileNavItems = document.querySelectorAll('.mobile-nav-item');
     mobileNavItems.forEach(item => {
         const page = item.dataset.page;
-        const isActive = page === activePage;
-        const isRefresh = item.dataset.action === 'refresh';
+        const action = item.dataset.action;
+
+        // Special case: highlight 'league' button when on my-team/leagues
+        let isActive = false;
+        if (action === 'league' && activePage === 'my-team' && subTab === 'leagues') {
+            isActive = true;
+        } else if (page === activePage && subTab === 'overview') {
+            isActive = true;
+        } else {
+            isActive = false;
+        }
+
+        const isRefresh = action === 'refresh';
 
         item.style.background = isRefresh ? 'var(--secondary-color)' : (isActive ? 'var(--bg-tertiary)' : 'transparent');
         const label = item.querySelector('span');
         if (label) {
-            label.style.fontWeight = isActive || item.dataset.action === 'refresh' ? '700' : '500';
+            label.style.fontWeight = isActive || isRefresh ? '700' : '500';
         }
     });
 }

--- a/frontend/src/renderMyTeam.js
+++ b/frontend/src/renderMyTeam.js
@@ -10,8 +10,7 @@ import {
 } from './data.js';
 
 import {
-    loadAndRenderLeagueInfo,
-    initializeLeagueSelector
+    loadAndRenderLeagueInfo
 } from './leagueInfo.js';
 
 import {
@@ -420,10 +419,9 @@ export function renderMyTeam(teamData, subTab = 'overview') {
         });
     }
 
-    // Initialize league selector and league info for mobile
+    // Initialize league info for mobile (shows league position in GW card)
     if (useMobile) {
         requestAnimationFrame(async () => {
-            await initializeLeagueSelector(teamData.team.id);
             await loadAndRenderLeagueInfo();
         });
     }

--- a/frontend/src/renderMyTeamCompact.js
+++ b/frontend/src/renderMyTeamCompact.js
@@ -200,35 +200,18 @@ export function renderCompactHeader(teamData, gwNumber) {
                     </div>
                 </div>
 
-                <div style="display: grid; gap: 0.3rem; flex-shrink: 0; min-width: 90px;">
-                    <!-- League Selector Dropdown -->
-                    <select
-                        id="mobile-league-selector"
-                        style="
-                            width: 100%;
-                            padding: 0.2rem 0.3rem;
-                            font-size: 0.65rem;
-                            background: var(--bg-secondary);
-                            border: 1px solid var(--border-color);
-                            border-radius: 0.25rem;
-                            color: var(--text-primary);
-                            cursor: pointer;
-                        "
-                    >
-                        <option value="">🏆 League</option>
-                    </select>
-
-                    <div style="
-                        background: var(--bg-secondary);
-                        border: 1px solid var(--border-color);
-                        border-radius: 6px;
-                        padding: 0.4rem 0.5rem;
-                    ">
-                        <div style="font-size: 1rem; font-weight: 700; color: ${gwTextColor}; line-height: 1.2;">
-                            GW${gwNumber}: ${gwPoints}
-                        </div>
-                        ${leagueInfo}
+                <div style="
+                    background: var(--bg-secondary);
+                    border: 1px solid var(--border-color);
+                    border-radius: 6px;
+                    padding: 0.4rem 0.5rem;
+                    min-width: 90px;
+                    flex-shrink: 0;
+                ">
+                    <div style="font-size: 1rem; font-weight: 700; color: ${gwTextColor}; line-height: 1.2;">
+                        GW${gwNumber}: ${gwPoints}
                     </div>
+                    ${leagueInfo}
                 </div>
             </div>
         </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -200,7 +200,7 @@ body {
   #app-container {
     padding: 0 !important;
     padding-top: 0 !important;
-    padding-bottom: 0 !important;
+    /* padding-bottom is managed by mobileNav.js for bottom nav clearance */
     margin: 0 auto !important;
   }
 


### PR DESCRIPTION
…scrolling

Mobile Navigation Highlighting:
- Update updateMobileNav() to accept subTab parameter
- Highlight 'league' button when on my-team/leagues subtab
- Fix issue where 'team' button stayed active on league view
- Pass currentSubTab from main.js to updateMobileNav()

League Selector Removal:
- Remove league selector from team page compact header
- Selector is redundant now that dedicated league tab exists
- Users can select league from league tab dropdown
- Remove initializeLeagueSelector() call from renderMyTeam
- Keep loadAndRenderLeagueInfo() for league position card in GW box

Fix Mobile Scrolling Issue:
- Remove padding-bottom: 0 !important from styles.css
- This was conflicting with mobileNav.js padding-bottom management
- Bottom nav padding is dynamically added by mobileNav.js
- Fixes issue where nav bar wasn't floating and page couldn't scroll
- Content now properly clears the fixed bottom navigation bar