### PR TITLE
fix: enable mobile scrolling and fine-tune opponent pill sizing

### DIFF
--- a/frontend/src/renderMyTeamCompact.js
+++ b/frontend/src/renderMyTeamCompact.js
@@ -88,7 +88,7 @@ export function renderCompactHeader(teamData, gwNumber) {
         const captainPlayer = getPlayerById(captainPick.element);
         if (captainPlayer) {
             const captainOpp = getGWOpponent(captainPlayer.team, gwNumber);
-            const oppBadge = `<span class="${getDifficultyClass(captainOpp.difficulty)}" style="padding: 0.1rem 0.3rem; border-radius: 0.3rem; font-weight: 600; font-size: 0.65rem; min-width: 3.5rem; display: inline-block; text-align: center;">${captainOpp.name} (${captainOpp.isHome ? 'H' : 'A'})</span>`;
+            const oppBadge = `<span class="${getDifficultyClass(captainOpp.difficulty)}" style="padding: 0.08rem 0.25rem; border-radius: 0.25rem; font-weight: 600; font-size: 0.62rem; min-width: 3rem; display: inline-block; text-align: center;">${captainOpp.name} (${captainOpp.isHome ? 'H' : 'A'})</span>`;
             captainInfo = `${captainPlayer.web_name} vs. ${oppBadge}`;
         }
     }
@@ -97,7 +97,7 @@ export function renderCompactHeader(teamData, gwNumber) {
         const vicePlayer = getPlayerById(vicePick.element);
         if (vicePlayer) {
             const viceOpp = getGWOpponent(vicePlayer.team, gwNumber);
-            const oppBadge = `<span class="${getDifficultyClass(viceOpp.difficulty)}" style="padding: 0.1rem 0.3rem; border-radius: 0.3rem; font-weight: 600; font-size: 0.65rem; min-width: 3.5rem; display: inline-block; text-align: center;">${viceOpp.name} (${viceOpp.isHome ? 'H' : 'A'})</span>`;
+            const oppBadge = `<span class="${getDifficultyClass(viceOpp.difficulty)}" style="padding: 0.08rem 0.25rem; border-radius: 0.25rem; font-weight: 600; font-size: 0.62rem; min-width: 3rem; display: inline-block; text-align: center;">${viceOpp.name} (${viceOpp.isHome ? 'H' : 'A'})</span>`;
             viceInfo = `${vicePlayer.web_name} vs. ${oppBadge}`;
         }
     }
@@ -293,7 +293,7 @@ export function renderCompactPlayerRow(pick, player, gwNumber) {
                 ${hasHighSeverity ? '<i class="fas fa-exclamation-triangle" style="color: var(--danger-color); font-size: 0.65rem; margin-left: 0.2rem;"></i>' : ''}
             </div>
             <div style="text-align: center;">
-                <span class="${getDifficultyClass(gwOpp.difficulty)}" style="padding: 0.1rem 0.3rem; border-radius: 0.3rem; font-weight: 600; font-size: 0.65rem; min-width: 3.5rem; display: inline-block; text-align: center;">
+                <span class="${getDifficultyClass(gwOpp.difficulty)}" style="padding: 0.08rem 0.25rem; border-radius: 0.25rem; font-weight: 600; font-size: 0.62rem; min-width: 3rem; display: inline-block; text-align: center;">
                     ${gwOpp.name} (${gwOpp.isHome ? 'H' : 'A'})
                 </span>
             </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -73,12 +73,20 @@
 }
 
 /* Base styles */
+html {
+    height: 100%;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
 body {
     font-family: 'Inter', sans-serif;
     background: var(--bg-primary);
     color: var(--text-primary);
     margin: 0;
     padding: 0;
+    min-height: 100%;
+    overflow-x: hidden;
 }
 
 /* Fixture difficulty classes */
@@ -200,7 +208,7 @@ body {
   #app-container {
     padding: 0 !important;
     padding-top: 0 !important;
-    padding-bottom: 0 !important;
+    /* padding-bottom managed dynamically by mobileNav.js */
     margin: 0 auto !important;
   }
 


### PR DESCRIPTION
Scrolling Fix:
- Remove padding-bottom: 0 !important from #app-container mobile styles
- This was preventing mobileNav.js from adding dynamic bottom padding
- Add explicit overflow and height properties to html/body
- html: height: 100%, overflow-y: auto, overflow-x: hidden
- body: min-height: 100%, overflow-x: hidden
- Bottom nav now properly fixed at bottom with scrollable content above

Opponent Pill Sizing:
- Reduce pill size slightly for better visual balance
- min-width: 3.5rem → 3rem
- padding: 0.1rem 0.3rem → 0.08rem 0.25rem
- font-size: 0.65rem → 0.62rem
- border-radius: 0.3rem → 0.25rem
- Applied to captain/vice captain info and player row opponents
- Prevents pills from appearing too large or expanding unexpectedly