### PR TITLE
fix: resolve mobile scrolling and bottom nav positioning in PWA

### DIFF
--- a/frontend/src/mobileNav.js
+++ b/frontend/src/mobileNav.js
@@ -27,6 +27,7 @@ export function createMobileNav(currentPage, onNavigate) {
                 bottom: 0;
                 left: 0;
                 right: 0;
+                width: 100%;
                 background: var(--bg-secondary);
                 border-top: 1px solid var(--border-color);
                 display: flex;
@@ -36,6 +37,7 @@ export function createMobileNav(currentPage, onNavigate) {
                 padding-bottom: max(0.4rem, env(safe-area-inset-bottom));
                 z-index: 1000;
                 gap: 0.25rem;
+                box-shadow: 0 -2px 8px rgba(0,0,0,0.1);
             "
         >
             ${navItems.map(item => {
@@ -201,12 +203,17 @@ function addMainContentPadding() {
     style.textContent = `
         @media (max-width: 767px) {
             #app-container {
-                padding-bottom: calc(5rem + env(safe-area-inset-bottom)) !important;
+                padding-bottom: calc(80px + env(safe-area-inset-bottom)) !important;
             }
 
             body {
                 padding-bottom: 0;
                 margin-bottom: 0;
+            }
+
+            /* Ensure smooth scrolling on iOS */
+            body {
+                -webkit-overflow-scrolling: touch;
             }
         }
     `;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -74,8 +74,8 @@
 
 /* Base styles */
 html {
-    height: 100%;
-    overflow-y: auto;
+    /* Don't constrain height - allow content to scroll */
+    min-height: 100vh;
     overflow-x: hidden;
 }
 
@@ -85,8 +85,11 @@ body {
     color: var(--text-primary);
     margin: 0;
     padding: 0;
-    min-height: 100%;
+    min-height: 100vh;
     overflow-x: hidden;
+    /* Enable vertical scrolling */
+    overflow-y: auto;
+    position: relative;
 }
 
 /* Fixture difficulty classes */
@@ -210,6 +213,15 @@ body {
     padding-top: 0 !important;
     /* padding-bottom is managed by mobileNav.js for bottom nav clearance */
     margin: 0 auto !important;
+    min-height: auto !important;
+  }
+
+  /* Ensure app wrapper doesn't interfere with scrolling */
+  #app {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    position: relative;
   }
 
   /* Compact header on mobile with safe area support */
@@ -217,6 +229,8 @@ body {
     padding: 0.75rem 1rem !important;
     padding-top: calc(0.75rem + env(safe-area-inset-top)) !important;
     margin-top: calc(-1 * env(safe-area-inset-top)) !important;
+    position: relative;
+    z-index: 900;
   }
 
   /* Extend purple background to top of screen */
@@ -227,6 +241,7 @@ body {
 
   #app-container {
     background: var(--bg-primary);
+    flex: 1;
   }
 
   nav h1 {


### PR DESCRIPTION
Root cause: html height constraint and missing overflow properties were preventing scrolling

Changes:
- Replace html height: 100% with min-height: 100vh to allow content to extend beyond viewport
- Add overflow-y: auto to body for vertical scrolling
- Add flexbox layout to #app wrapper for proper page structure
- Enhance bottom nav with explicit width and improved positioning
- Update content padding from 5rem to 80px for precision
- Add -webkit-overflow-scrolling for smooth iOS scrolling

Fixes:
- Bottom nav now properly fixed to viewport bottom
- Page content scrolls normally without being cut off
- Content no longer hidden behind bottom navigation bar