### PR TITLE
fix: force all mobile tables to truly flush to screen edges

### DIFF
--- a/frontend/src/renderMyTeam.js
+++ b/frontend/src/renderMyTeam.js
@@ -1140,6 +1140,8 @@ function renderMobileFixturesTab() {
                         border-bottom: 1px solid var(--border-color);
                         font-size: 0.75rem;
                         align-items: center;
+                        width: 100vw;
+                        margin-left: calc(-50vw + 50%);
                     ">
                         <div style="color: var(--text-secondary); font-size: 0.65rem;">${timeStr.split(',')[1] || timeStr}</div>
                         <div style="text-align: right; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
@@ -1172,6 +1174,8 @@ function renderMobileFixturesTab() {
                     position: sticky;
                     top: calc(3.5rem + env(safe-area-inset-top));
                     z-index: 50;
+                    width: 100vw;
+                    margin-left: calc(-50vw + 50%);
                 ">
                     <div>Time</div>
                     <div style="text-align: right;">Home</div>
@@ -1463,6 +1467,8 @@ function renderLeagueStandings(leagueData) {
                 position: sticky;
                 top: calc(3.5rem + 8rem + env(safe-area-inset-top));
                 z-index: 50;
+                width: 100vw;
+                margin-left: calc(-50vw + 50%);
             ">
                 <div style="text-align: center; padding-left: 0;">Rank</div>
                 <div>Manager</div>
@@ -1516,6 +1522,8 @@ function renderLeagueStandings(leagueData) {
                     ${isUser ? 'border-left: 3px solid var(--primary-color);' : ''}
                     font-size: 0.75rem;
                     align-items: center;
+                    width: 100vw;
+                    margin-left: calc(-50vw + 50%);
                 ">
                     <div style="text-align: center; padding-left: 0;">
                         <div style="font-weight: 600;">${entry.rank}</div>

--- a/frontend/src/renderMyTeamCompact.js
+++ b/frontend/src/renderMyTeamCompact.js
@@ -151,6 +151,8 @@ export function renderCompactHeader(teamData, gwNumber) {
                 padding: 0.5rem 0;
                 border-bottom: 2px solid var(--border-color);
                 margin: 0;
+                width: 100vw;
+                margin-left: calc(-50vw + 50%);
             "
         >
             <div style="display: flex; justify-content: space-between; align-items: flex-start; gap: 0.5rem; padding: 0;">
@@ -271,6 +273,8 @@ export function renderCompactPlayerRow(pick, player, gwNumber) {
             border-bottom: 1px solid var(--border-color);
             font-size: 0.75rem;
             align-items: center;
+            width: 100vw;
+            margin-left: calc(-50vw + 50%);
         ">
             <div style="font-weight: 600; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; padding-left: 0;">
                 ${escapeHtml(player.web_name)}${captainBadge}
@@ -311,6 +315,8 @@ export function renderCompactTeamList(players, gwNumber) {
             font-size: 0.7rem;
             font-weight: 700;
             text-transform: capitalize;
+            width: 100vw;
+            margin-left: calc(-50vw + 50%);
         ">
             <div style="padding-left: 0;">Player</div>
             <div style="text-align: center;">Opp</div>


### PR DESCRIPTION
Apply full-width breakout technique using width: 100vw and negative margin to ensure ALL tables touch screen edges regardless of parent container padding.

Changes:
- Compact header: add width: 100vw + margin-left: calc(-50vw + 50%)
- Team table header row: force full width breakout
- Team table player rows: force full width breakout
- League table header row: force full width breakout
- League table entry rows: force full width breakout
- Fixtures table header row: force full width breakout
- Fixtures table match rows: force full width breakout

This CSS technique makes elements break out of any parent padding/constraints and extend to the full viewport width, ensuring pixel-perfect edge-to-edge layout.