### PR TITLE
feat: restore 'close to perfect' padding from commit 9a0c77b

### DIFF
--- a/frontend/src/renderMyTeam.js
+++ b/frontend/src/renderMyTeam.js
@@ -1133,15 +1133,13 @@ function renderMobileFixturesTab() {
                         display: grid;
                         grid-template-columns: 0.8fr 2fr 1fr 2fr 0.6fr;
                         gap: 0.25rem;
-                        padding: 0.5rem 0;
+                        padding: 0.4rem 0.5rem;
                         background: ${isStarted && !isFinished ? 'rgba(239, 68, 68, 0.05)' : 'transparent'};
                         border-bottom: 1px solid var(--border-color);
                         font-size: 0.75rem;
                         align-items: center;
-                        width: 100vw;
-                        margin-left: calc(-50vw + 50%);
                     ">
-                        <div style="color: var(--text-secondary); font-size: 0.65rem; padding-left: 0.5rem;">${timeStr.split(',')[1] || timeStr}</div>
+                        <div style="color: var(--text-secondary); font-size: 0.65rem;">${timeStr.split(',')[1] || timeStr}</div>
                         <div style="text-align: right; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
                             ${homeTeam?.short_name || 'TBD'}
                         </div>
@@ -1151,7 +1149,7 @@ function renderMobileFixturesTab() {
                         <div style="text-align: left; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
                             ${awayTeam?.short_name || 'TBD'}
                         </div>
-                        <div style="text-align: center; padding-right: 0.5rem;">
+                        <div style="text-align: center;">
                             ${statusBadge}
                         </div>
                     </div>
@@ -1164,7 +1162,7 @@ function renderMobileFixturesTab() {
                     display: grid;
                     grid-template-columns: 0.8fr 2fr 1fr 2fr 0.6fr;
                     gap: 0.25rem;
-                    padding: 0.4rem 0;
+                    padding: 0.4rem 0.5rem;
                     background: var(--primary-color);
                     color: white;
                     font-size: 0.7rem;
@@ -1172,14 +1170,12 @@ function renderMobileFixturesTab() {
                     position: sticky;
                     top: calc(3.5rem + env(safe-area-inset-top));
                     z-index: 50;
-                    width: 100vw;
-                    margin-left: calc(-50vw + 50%);
                 ">
-                    <div style="padding-left: 0.5rem;">Time</div>
+                    <div>Time</div>
                     <div style="text-align: right;">Home</div>
                     <div style="text-align: center;">Score</div>
                     <div style="text-align: left;">Away</div>
-                    <div style="text-align: center; padding-right: 0.5rem;">Status</div>
+                    <div style="text-align: center;">Status</div>
                 </div>
             `;
 
@@ -1456,7 +1452,7 @@ function renderLeagueStandings(leagueData) {
                 display: grid;
                 grid-template-columns: 0.7fr 2fr 0.7fr 0.8fr 0.8fr;
                 gap: 0.25rem;
-                padding: 0.4rem 0;
+                padding: 0.4rem 0.5rem;
                 background: var(--primary-color);
                 color: white;
                 font-size: 0.7rem;
@@ -1465,14 +1461,12 @@ function renderLeagueStandings(leagueData) {
                 position: sticky;
                 top: calc(3.5rem + 8rem + env(safe-area-inset-top));
                 z-index: 50;
-                width: 100vw;
-                margin-left: calc(-50vw + 50%);
             ">
-                <div style="text-align: center; padding-left: 0.5rem;">Rank</div>
+                <div style="text-align: center;">Rank</div>
                 <div>Manager</div>
                 <div style="text-align: center;">GW</div>
                 <div style="text-align: center;">Total</div>
-                <div style="text-align: center; padding-right: 0.5rem;">Gap</div>
+                <div style="text-align: center;">Gap</div>
             </div>
         `;
 
@@ -1514,16 +1508,14 @@ function renderLeagueStandings(leagueData) {
                     display: grid;
                     grid-template-columns: 0.7fr 2fr 0.7fr 0.8fr 0.8fr;
                     gap: 0.25rem;
-                    padding: 0.1rem 0;
+                    padding: 0.4rem 0.5rem;
                     background: ${bgColor};
                     border-bottom: 1px solid var(--border-color);
                     ${isUser ? 'border-left: 3px solid var(--primary-color);' : ''}
                     font-size: 0.75rem;
                     align-items: center;
-                    width: 100vw;
-                    margin-left: calc(-50vw + 50%);
                 ">
-                    <div style="text-align: center; padding-left: 0.5rem;">
+                    <div style="text-align: center;">
                         <div style="font-weight: 600;">${entry.rank}</div>
                         <div style="font-size: 0.6rem; color: ${rankChangeColor};">
                             ${rankChangeIcon}
@@ -1537,7 +1529,7 @@ function renderLeagueStandings(leagueData) {
                         ${gwPoints}
                     </div>
                     <div style="text-align: center; font-weight: 600;">${entry.total.toLocaleString()}</div>
-                    <div style="text-align: center; font-weight: 600; color: ${gapColor}; font-size: 0.7rem; padding-right: 0.5rem;">
+                    <div style="text-align: center; font-weight: 600; color: ${gapColor}; font-size: 0.7rem;">
                         ${gapText}
                     </div>
                 </div>

--- a/frontend/src/renderMyTeamCompact.js
+++ b/frontend/src/renderMyTeamCompact.js
@@ -148,14 +148,12 @@ export function renderCompactHeader(teamData, gwNumber) {
                 top: calc(3.5rem + env(safe-area-inset-top)); /* Keeps this box sticky just below the top app bar */
                 background: var(--bg-primary);
                 z-index: 100;
-                padding: 0.5rem 0;
+                padding: 0.5rem 0.75rem;
                 border-bottom: 2px solid var(--border-color);
                 margin: 0;
-                width: 100vw;
-                margin-left: calc(-50vw + 50%);
             "
         >
-            <div style="display: flex; justify-content: space-between; align-items: flex-start; gap: 0.5rem; padding: 0 0.5rem;">
+            <div style="display: flex; justify-content: space-between; align-items: flex-start; gap: 0.5rem;">
                 <div style="flex: 1; display: grid; gap: 0.2rem; padding-left: 0;">
                     <div style="display: flex; align-items: center; gap: 0.4rem;">
                         <button
@@ -268,15 +266,13 @@ export function renderCompactPlayerRow(pick, player, gwNumber) {
             display: grid;
             grid-template-columns: 2.5fr 1fr 0.7fr 0.6fr 0.6fr 0.7fr 0.6fr;
             gap: 0.25rem;
-            padding: 0.1rem 0;
+            padding: 0.4rem 0.5rem;
             background: ${finalBg};
             border-bottom: 1px solid var(--border-color);
             font-size: 0.75rem;
             align-items: center;
-            width: 100vw;
-            margin-left: calc(-50vw + 50%);
         ">
-            <div style="font-weight: 600; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; padding-left: 0.5rem;">
+            <div style="font-weight: 600; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
                 ${escapeHtml(player.web_name)}${captainBadge}
                 ${hasHighSeverity ? '<i class="fas fa-exclamation-triangle" style="color: var(--danger-color); font-size: 0.65rem; margin-left: 0.2rem;"></i>' : ''}
             </div>
@@ -289,7 +285,7 @@ export function renderCompactPlayerRow(pick, player, gwNumber) {
             <div style="text-align: center; background: ${ptsStyle.background}; color: ${ptsStyle.color}; font-weight: 700; padding: 0.05rem; border-radius: 0.2rem; font-size: 0.7rem;">${displayPoints}</div>
             <div style="text-align: center; background: ${formStyle.background}; color: ${formStyle.color}; font-weight: 600; padding: 0.05rem; border-radius: 0.2rem; font-size: 0.65rem;">${formatDecimal(player.form)}</div>
             <div style="text-align: center; font-size: 0.65rem; color: var(--text-secondary);">${ownership.toFixed(1)}%</div>
-            <div style="text-align: center; font-size: 0.65rem; font-weight: 600; color: ${transferColor}; padding-right: 0.5rem;">
+            <div style="text-align: center; font-size: 0.65rem; font-weight: 600; color: ${transferColor};">
                 ${netTransfers > 0 ? '+' : ''}${(netTransfers / 1000).toFixed(0)}k
             </div>
         </div>
@@ -309,22 +305,20 @@ export function renderCompactTeamList(players, gwNumber) {
             display: grid;
             grid-template-columns: 2.5fr 1fr 0.7fr 0.6fr 0.6fr 0.7fr 0.6fr;
             gap: 0.25rem;
-            padding: 0.4rem 0;
+            padding: 0.4rem 0.5rem;
             background: var(--primary-color);
             color: white;
             font-size: 0.7rem;
             font-weight: 700;
             text-transform: capitalize;
-            width: 100vw;
-            margin-left: calc(-50vw + 50%);
         ">
-            <div style="padding-left: 0.5rem;">Player</div>
+            <div>Player</div>
             <div style="text-align: center;">Opp</div>
             <div style="text-align: center;">Mins</div>
             <div style="text-align: center;">Pts</div>
             <div style="text-align: center;">Form</div>
             <div style="text-align: center;">Own%</div>
-            <div style="text-align: center; padding-right: 0.5rem;">ΔT</div>
+            <div style="text-align: center;">ΔT</div>
         </div>
     `;
 


### PR DESCRIPTION
Reverted aggressive edge-to-edge layout and restored industry-standard padding:
- Removed width: 100vw and margin-left: calc(-50vw + 50%) breakout technique
- Compact header: padding 0.5rem 0.75rem (was 0.5rem 0)
- Table headers: padding 0.4rem 0.5rem (was 0.4rem 0)
- Table rows: padding 0.4rem 0.5rem (was 0.1rem 0)
- Removed edge-specific padding from individual cells

Applied consistently to:
- Team table (renderMyTeamCompact.js)
- League table (renderMyTeam.js)
- Fixtures table (renderMyTeam.js)

This restores the balanced padding approach that provides proper spacing without forcing tables to touch screen edges.