### PR TITLE
fix: resolve iOS Safari scrolling and table header visibility issues

### DIFF
--- a/frontend/src/renderMyTeamCompact.js
+++ b/frontend/src/renderMyTeamCompact.js
@@ -306,11 +306,12 @@ export function renderCompactTeamList(players, gwNumber) {
             grid-template-columns: 2.5fr 1fr 0.7fr 0.6fr 0.6fr 0.7fr 0.6fr;
             gap: 0.25rem;
             padding: 0.4rem 0.75rem;
-            background: var(--primary-color);
-            color: white;
+            background: var(--bg-secondary);
+            color: var(--text-primary);
             font-size: 0.7rem;
             font-weight: 700;
             text-transform: capitalize;
+            border-top: 2px solid var(--border-color);
         ">
             <div>Player</div>
             <div style="text-align: center;">Opp</div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -218,7 +218,6 @@ body {
 
   /* Ensure app wrapper doesn't interfere with scrolling */
   #app {
-    min-height: 100vh;
     display: flex;
     flex-direction: column;
     position: relative;
@@ -241,7 +240,7 @@ body {
 
   #app-container {
     background: var(--bg-primary);
-    flex: 1;
+    min-height: 100vh;
   }
 
   nav h1 {


### PR DESCRIPTION
- Remove min-height: 100vh constraint from #app to enable proper scrolling on iOS Safari
- Change #app-container from flex: 1 to min-height: 100vh for proper height
- Update table header background from purple to secondary color for visibility
- Add border-top to table header for better visual separation
- Change header text from white to primary text color for better contrast

These fixes ensure the app scrolls properly on both PWA and iOS Safari, and the table header is clearly visible against the purple body background.