### PR TITLE
fix: increase PWA positioning and add League page top padding

### DIFF
--- a/frontend/src/renderMyTeam.js
+++ b/frontend/src/renderMyTeam.js
@@ -646,7 +646,7 @@ function renderMobileLeaguesTab(teamData) {
 
     // Render league selector dropdown and standings
     const html = `
-        <div style="padding: 0;">
+        <div style="padding: 0.75rem 0 0 0;">
             <!-- League Selector -->
             <div style="margin-bottom: 1rem; padding: 0 0.75rem;">
                 <label style="font-size: 0.75rem; color: var(--text-secondary); display: block; margin-bottom: 0.25rem;">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -245,7 +245,7 @@ body {
   @media (display-mode: standalone) {
     /* In PWA mode, add consistent top spacing to match Safari experience */
     nav {
-      padding-top: 2rem !important;
+      padding-top: 2.5rem !important;
       margin-top: 0 !important;
     }
 
@@ -254,7 +254,7 @@ body {
     }
 
     #compact-header {
-      top: 4.75rem !important;
+      top: 5.25rem !important;
     }
   }
 


### PR DESCRIPTION
PWA positioning adjustments:
- Increased nav padding-top from 2rem to 2.5rem in standalone mode
- Increased compact header top from 4.75rem to 5.25rem in standalone mode

This moves all PWA content even lower to better align with the Safari mobile experience.

League page adjustments:
- Added 0.75rem top padding to League selector container
- Provides proper clearance from the app header
- Ensures League dropdown doesn't feel cramped at the top

Both changes improve spacing and visual comfort on mobile.