### PR TITLE
feat: align Team page header card to table borders

### DIFF
--- a/frontend/src/renderMyTeamCompact.js
+++ b/frontend/src/renderMyTeamCompact.js
@@ -154,8 +154,8 @@ export function renderCompactHeader(teamData, gwNumber) {
                 margin: 0;
             "
         >
-            <div style="display: flex; justify-content: space-between; align-items: flex-start; gap: 0.5rem; padding: 0 0.75rem;">
-                <div style="flex: 1; display: grid; gap: 0.2rem; padding-left: 0;">
+            <div style="display: flex; justify-content: space-between; align-items: stretch; gap: 0.5rem;">
+                <div style="flex: 1; display: grid; gap: 0.2rem; padding-left: 0.75rem;">
                     <div style="display: flex; align-items: center; gap: 0.4rem;">
                         <button
                             id="change-team-btn"
@@ -189,14 +189,17 @@ export function renderCompactHeader(teamData, gwNumber) {
                     </div>
                 </div>
 
-                <div style="display: grid; gap: 0.3rem; flex-shrink: 0;">
+                <div style="display: flex; align-items: stretch; padding-right: 0.75rem;">
                     <div style="
                         background: var(--bg-secondary);
                         border: 1px solid var(--border-color);
                         border-radius: 6px;
-                        padding: 0.5rem 0.75rem;
+                        padding: 0.6rem 0.75rem;
                         text-align: center;
                         min-width: 90px;
+                        display: flex;
+                        flex-direction: column;
+                        justify-content: center;
                     ">
                         <div style="font-size: 1.75rem; font-weight: 800; color: ${gwTextColor}; line-height: 1;">
                             ${gwPoints}


### PR DESCRIPTION
- Remove outer padding from header flex container
- Add left padding to team info section (0.75rem)
- Add right padding to score card section (0.75rem)
- Match score card height to left section using flex stretch
- Improve visual alignment between header and player table