### PR TITLE
refactor: simplify player modal to basic placeholder and make table e…

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -77,20 +77,6 @@
 
     <script type="module" src="/src/main.js"></script>
 
-    <!-- Mobile Debug Console (Temporary) -->
-    <script src="https://cdn.jsdelivr.net/npm/eruda"></script>
-    <script>
-        // Initialize Eruda console for debugging
-        window.addEventListener('load', function() {
-            if (typeof eruda !== 'undefined') {
-                eruda.init();
-                console.log('🔍 Eruda mobile console enabled - tap the icon in bottom-right corner');
-            } else {
-                console.log('❌ Eruda failed to load');
-            }
-        });
-    </script>
-
     <!-- Service Worker Registration -->
     <script>
         // Register service worker for PWA support

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -126,8 +126,8 @@ body {
   /* Mobile container */
   .container-mobile {
     width: 100%;
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-left: 0;
+    padding-right: 0;
   }
 
   /* Desktop container */


### PR DESCRIPTION
…dge-to-edge

Modal changes:
- Revert to simple placeholder with just player name and ID
- Remove all comprehensive stats sections
- Remove debug console logging
- Simple close button for testing

Layout changes:
- Remove mobile container padding (1rem left/right) for edge-to-edge display
- Card header and table now touch screen edges on mobile
- Desktop padding (2rem) preserved

Debug cleanup:
- Remove Eruda mobile console library
- Remove all console.log statements