### PR TITLE
fix: remove inline padding and handle all padding via CSS media queries

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -67,7 +67,7 @@
         </nav>
 
         <!-- Main Content -->
-        <main id="app-container" style="max-width: 1400px; margin: 2rem auto; padding: 0 2rem;">
+        <main id="app-container" style="max-width: 1400px; margin: 2rem auto;">
             <div style="text-align: center; padding: 4rem 2rem; color: var(--text-secondary);">
                 <i class="fas fa-spinner fa-spin" style="font-size: 3rem; margin-bottom: 1rem;"></i>
                 <p>Loading FPLanner...</p>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -263,6 +263,13 @@ body {
   }
 }
 
+/* Desktop padding */
+@media (min-width: 1024px) {
+  #app-container {
+    padding: 0 2rem !important;
+  }
+}
+
 /* Mobile interaction polish */
 @media (max-width: 767px) {
   /* Smooth button interactions */


### PR DESCRIPTION
- Remove 'padding: 0 2rem' from inline style in index.html
- Mobile (<=767px): padding: 0 (edge-to-edge display)
- Tablet (768px-1023px): padding: 1.5rem
- Desktop (>=1024px): padding: 0 2rem
- Team table should now match fixtures table width on mobile