### PR TITLE
fix: remove stray template literal backtick causing build error

### DIFF
--- a/frontend/src/renderMyTeam.js
+++ b/frontend/src/renderMyTeam.js
@@ -1674,8 +1674,6 @@ window.toggleProblemPlayers = function() {
         icon.classList.remove('fa-chevron-up');
         icon.classList.add('fa-chevron-down');
     }
-    `;
-}
 }
 
 // ============================================================================


### PR DESCRIPTION
Fixed syntax error in renderMyTeam.js at line 1677 where a stray template literal backtick and extra closing brace were causing production build failures.