### PR TITLE
fix(backend): add fplanner.onrender.com to CORS allowed origins

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -74,9 +74,12 @@ export const TTL = {
 export const ALLOWED_ORIGINS = [
   'http://localhost:5173',         // Vite dev server
   'http://localhost:3000',         // Alternative dev port
-  'https://fplanner.vercel.app',   // Production domain
+  'http://localhost:3001',         // Backend dev
+  'https://fplanner.onrender.com', // Production domain (Render)
+  'https://fplanner.vercel.app',   // Production domain (Vercel)
   'https://fplanner-git-*.vercel.app', // Preview deployments (wildcard handled in server)
-];
+  process.env.ALLOWED_ORIGIN,      // Custom domain from env var
+].filter(Boolean);
 
 // ============================================================================
 // RATE LIMITING CONFIGURATION


### PR DESCRIPTION
CRITICAL FIX: Production domain was missing from ALLOWED_ORIGINS causing CORS errors and blocking all API requests.

Added:
- https://fplanner.onrender.com (production)
- http://localhost:3001 (backend dev)
- process.env.ALLOWED_ORIGIN support with filter(Boolean)

This fixes the 'Not allowed by CORS' errors in production.