### PR TITLE
fix(frontend): correct isMobileDevice import + add test infrastructure

### DIFF
--- a/frontend/src/dataAnalysis/playerTableRenderer.js
+++ b/frontend/src/dataAnalysis/playerTableRenderer.js
@@ -4,7 +4,8 @@
 // ============================================================================
 
 import { currentGW } from '../data.js';
-import { isMobileDevice, getHeatmapStyle } from '../utils.js';
+import { getHeatmapStyle } from '../utils.js';
+import { isMobileDevice } from '../renderMyTeamMobile.js';
 import {
     getTableConfig,
     getFixtureHeaders,

--- a/frontend/tests/dataAnalysis.test.js
+++ b/frontend/tests/dataAnalysis.test.js
@@ -1,0 +1,131 @@
+/**
+ * Data Analysis Module Tests
+ * Tests for refactored Data Analysis modules
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// Test imports from main file
+import {
+    renderAnalysisOverview,
+    renderDifferentials
+} from '../src/renderDataAnalysis.js';
+
+// Test imports from modules
+import {
+    TABLE_CONFIGS,
+    getTableConfig,
+    getFixtureHeaders,
+    getNextFixtures
+} from '../src/dataAnalysis/tableConfigs.js';
+
+import {
+    filterByPosition,
+    filterByOwnership,
+    filterByPriceRange,
+    filterByFixtureDifficulty,
+    filterByMomentum,
+    applyDifferentialFilters
+} from '../src/dataAnalysis/filterHelpers.js';
+
+import {
+    renderPlayerTableDesktop,
+    renderPlayerTableMobile,
+    renderPlayerTable
+} from '../src/dataAnalysis/playerTableRenderer.js';
+
+import {
+    renderDifferentials as renderDifferentialsModule
+} from '../src/dataAnalysis/differentials.js';
+
+describe('Data Analysis - Module Imports', () => {
+    describe('renderDataAnalysis.js', () => {
+        it('should export renderAnalysisOverview', () => {
+            expect(renderAnalysisOverview).toBeDefined();
+            expect(typeof renderAnalysisOverview).toBe('function');
+        });
+
+        it('should export renderDifferentials', () => {
+            expect(renderDifferentials).toBeDefined();
+            expect(typeof renderDifferentials).toBe('function');
+        });
+    });
+
+    describe('tableConfigs.js', () => {
+        it('should export TABLE_CONFIGS', () => {
+            expect(TABLE_CONFIGS).toBeDefined();
+            expect(typeof TABLE_CONFIGS).toBe('object');
+        });
+
+        it('should export getTableConfig', () => {
+            expect(getTableConfig).toBeDefined();
+            expect(typeof getTableConfig).toBe('function');
+        });
+
+        it('should export getFixtureHeaders', () => {
+            expect(getFixtureHeaders).toBeDefined();
+            expect(typeof getFixtureHeaders).toBe('function');
+        });
+
+        it('should export getNextFixtures', () => {
+            expect(getNextFixtures).toBeDefined();
+            expect(typeof getNextFixtures).toBe('function');
+        });
+    });
+
+    describe('filterHelpers.js', () => {
+        it('should export filterByPosition', () => {
+            expect(filterByPosition).toBeDefined();
+            expect(typeof filterByPosition).toBe('function');
+        });
+
+        it('should export filterByOwnership', () => {
+            expect(filterByOwnership).toBeDefined();
+            expect(typeof filterByOwnership).toBe('function');
+        });
+
+        it('should export filterByPriceRange', () => {
+            expect(filterByPriceRange).toBeDefined();
+            expect(typeof filterByPriceRange).toBe('function');
+        });
+
+        it('should export filterByFixtureDifficulty', () => {
+            expect(filterByFixtureDifficulty).toBeDefined();
+            expect(typeof filterByFixtureDifficulty).toBe('function');
+        });
+
+        it('should export filterByMomentum', () => {
+            expect(filterByMomentum).toBeDefined();
+            expect(typeof filterByMomentum).toBe('function');
+        });
+
+        it('should export applyDifferentialFilters', () => {
+            expect(applyDifferentialFilters).toBeDefined();
+            expect(typeof applyDifferentialFilters).toBe('function');
+        });
+    });
+
+    describe('playerTableRenderer.js', () => {
+        it('should export renderPlayerTableDesktop', () => {
+            expect(renderPlayerTableDesktop).toBeDefined();
+            expect(typeof renderPlayerTableDesktop).toBe('function');
+        });
+
+        it('should export renderPlayerTableMobile', () => {
+            expect(renderPlayerTableMobile).toBeDefined();
+            expect(typeof renderPlayerTableMobile).toBe('function');
+        });
+
+        it('should export renderPlayerTable', () => {
+            expect(renderPlayerTable).toBeDefined();
+            expect(typeof renderPlayerTable).toBe('function');
+        });
+    });
+
+    describe('differentials.js', () => {
+        it('should export renderDifferentials', () => {
+            expect(renderDifferentialsModule).toBeDefined();
+            expect(typeof renderDifferentialsModule).toBe('function');
+        });
+    });
+});

--- a/frontend/tests/myTeam/compact.test.js
+++ b/frontend/tests/myTeam/compact.test.js
@@ -1,0 +1,157 @@
+/**
+ * My Team Compact Module Tests
+ * Tests for refactored My Team Compact modules
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// Test imports from main file
+import {
+    renderCompactHeader,
+    renderCompactPlayerRow,
+    renderCompactTeamList,
+    renderMatchSchedule,
+    showPlayerModal,
+    closePlayerModal,
+    attachPlayerRowListeners
+} from '../../src/renderMyTeamCompact.js';
+
+// Test imports from modules
+import {
+    renderOpponentBadge,
+    renderStatCard,
+    calculateRankColor,
+    calculateGWTextColor,
+    calculateStatusColor,
+    calculatePlayerBgColor
+} from '../../src/myTeam/compact/compactStyleHelpers.js';
+
+import {
+    renderCompactHeader as renderCompactHeaderModule
+} from '../../src/myTeam/compact/compactHeader.js';
+
+import {
+    renderCompactPlayerRow as renderCompactPlayerRowModule
+} from '../../src/myTeam/compact/compactPlayerRow.js';
+
+import {
+    renderCompactTeamList as renderCompactTeamListModule
+} from '../../src/myTeam/compact/compactTeamList.js';
+
+import {
+    renderMatchSchedule as renderMatchScheduleModule
+} from '../../src/myTeam/compact/compactSchedule.js';
+
+import {
+    showPlayerModal as showPlayerModalModule,
+    closePlayerModal as closePlayerModalModule
+} from '../../src/myTeam/compact/playerModal.js';
+
+import {
+    attachPlayerRowListeners as attachPlayerRowListenersModule
+} from '../../src/myTeam/compact/compactEventHandlers.js';
+
+describe('My Team Compact - Module Imports', () => {
+    describe('renderMyTeamCompact.js (re-exports)', () => {
+        it('should export renderCompactHeader', () => {
+            expect(renderCompactHeader).toBeDefined();
+            expect(typeof renderCompactHeader).toBe('function');
+        });
+
+        it('should export renderCompactPlayerRow', () => {
+            expect(renderCompactPlayerRow).toBeDefined();
+            expect(typeof renderCompactPlayerRow).toBe('function');
+        });
+
+        it('should export renderCompactTeamList', () => {
+            expect(renderCompactTeamList).toBeDefined();
+            expect(typeof renderCompactTeamList).toBe('function');
+        });
+
+        it('should export renderMatchSchedule', () => {
+            expect(renderMatchSchedule).toBeDefined();
+            expect(typeof renderMatchSchedule).toBe('function');
+        });
+
+        it('should export showPlayerModal', () => {
+            expect(showPlayerModal).toBeDefined();
+            expect(typeof showPlayerModal).toBe('function');
+        });
+
+        it('should export closePlayerModal', () => {
+            expect(closePlayerModal).toBeDefined();
+            expect(typeof closePlayerModal).toBe('function');
+        });
+
+        it('should export attachPlayerRowListeners', () => {
+            expect(attachPlayerRowListeners).toBeDefined();
+            expect(typeof attachPlayerRowListeners).toBe('function');
+        });
+    });
+
+    describe('compactStyleHelpers.js', () => {
+        it('should export renderOpponentBadge', () => {
+            expect(renderOpponentBadge).toBeDefined();
+            expect(typeof renderOpponentBadge).toBe('function');
+        });
+
+        it('should export renderStatCard', () => {
+            expect(renderStatCard).toBeDefined();
+            expect(typeof renderStatCard).toBe('function');
+        });
+
+        it('should export calculateRankColor', () => {
+            expect(calculateRankColor).toBeDefined();
+            expect(typeof calculateRankColor).toBe('function');
+        });
+
+        it('should export calculateGWTextColor', () => {
+            expect(calculateGWTextColor).toBeDefined();
+            expect(typeof calculateGWTextColor).toBe('function');
+        });
+
+        it('should export calculateStatusColor', () => {
+            expect(calculateStatusColor).toBeDefined();
+            expect(typeof calculateStatusColor).toBe('function');
+        });
+
+        it('should export calculatePlayerBgColor', () => {
+            expect(calculatePlayerBgColor).toBeDefined();
+            expect(typeof calculatePlayerBgColor).toBe('function');
+        });
+    });
+
+    describe('Individual module files', () => {
+        it('should import compactHeader module', () => {
+            expect(renderCompactHeaderModule).toBeDefined();
+            expect(typeof renderCompactHeaderModule).toBe('function');
+        });
+
+        it('should import compactPlayerRow module', () => {
+            expect(renderCompactPlayerRowModule).toBeDefined();
+            expect(typeof renderCompactPlayerRowModule).toBe('function');
+        });
+
+        it('should import compactTeamList module', () => {
+            expect(renderCompactTeamListModule).toBeDefined();
+            expect(typeof renderCompactTeamListModule).toBe('function');
+        });
+
+        it('should import compactSchedule module', () => {
+            expect(renderMatchScheduleModule).toBeDefined();
+            expect(typeof renderMatchScheduleModule).toBe('function');
+        });
+
+        it('should import playerModal module', () => {
+            expect(showPlayerModalModule).toBeDefined();
+            expect(typeof showPlayerModalModule).toBe('function');
+            expect(closePlayerModalModule).toBeDefined();
+            expect(typeof closePlayerModalModule).toBe('function');
+        });
+
+        it('should import compactEventHandlers module', () => {
+            expect(attachPlayerRowListenersModule).toBeDefined();
+            expect(typeof attachPlayerRowListenersModule).toBe('function');
+        });
+    });
+});

--- a/frontend/tests/teamBuilder/modules.test.js
+++ b/frontend/tests/teamBuilder/modules.test.js
@@ -1,0 +1,124 @@
+/**
+ * Team Builder Module Tests
+ * Tests for refactored Team Builder modules
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// Test imports from modules
+import {
+    renderTeamInfoCard,
+    renderPlanTabs,
+    renderTransferSummary,
+    renderPlanningHorizonControl,
+    renderGameweekTabs,
+    renderActionButtons
+} from '../../src/teamBuilder/displayRenderers.js';
+
+import {
+    renderGameweekContent,
+    renderChipSelector,
+    renderTransferRow,
+    renderAutoSuggestionsPlaceholder,
+    renderAutoSuggestions
+} from '../../src/teamBuilder/transferRenderers.js';
+
+import {
+    renderProjectedSquad
+} from '../../src/teamBuilder/squadRenderers.js';
+
+import {
+    showSquadSelectionModal,
+    showReplacementSelectionModal
+} from '../../src/teamBuilder/playerModals.js';
+
+import {
+    handlePlanningHorizonChange
+} from '../../src/teamBuilder/horizonManager.js';
+
+describe('Team Builder - Module Imports', () => {
+    describe('displayRenderers.js', () => {
+        it('should export renderTeamInfoCard', () => {
+            expect(renderTeamInfoCard).toBeDefined();
+            expect(typeof renderTeamInfoCard).toBe('function');
+        });
+
+        it('should export renderPlanTabs', () => {
+            expect(renderPlanTabs).toBeDefined();
+            expect(typeof renderPlanTabs).toBe('function');
+        });
+
+        it('should export renderTransferSummary', () => {
+            expect(renderTransferSummary).toBeDefined();
+            expect(typeof renderTransferSummary).toBe('function');
+        });
+
+        it('should export renderPlanningHorizonControl', () => {
+            expect(renderPlanningHorizonControl).toBeDefined();
+            expect(typeof renderPlanningHorizonControl).toBe('function');
+        });
+
+        it('should export renderGameweekTabs', () => {
+            expect(renderGameweekTabs).toBeDefined();
+            expect(typeof renderGameweekTabs).toBe('function');
+        });
+
+        it('should export renderActionButtons', () => {
+            expect(renderActionButtons).toBeDefined();
+            expect(typeof renderActionButtons).toBe('function');
+        });
+    });
+
+    describe('transferRenderers.js', () => {
+        it('should export renderGameweekContent', () => {
+            expect(renderGameweekContent).toBeDefined();
+            expect(typeof renderGameweekContent).toBe('function');
+        });
+
+        it('should export renderChipSelector', () => {
+            expect(renderChipSelector).toBeDefined();
+            expect(typeof renderChipSelector).toBe('function');
+        });
+
+        it('should export renderTransferRow', () => {
+            expect(renderTransferRow).toBeDefined();
+            expect(typeof renderTransferRow).toBe('function');
+        });
+
+        it('should export renderAutoSuggestionsPlaceholder', () => {
+            expect(renderAutoSuggestionsPlaceholder).toBeDefined();
+            expect(typeof renderAutoSuggestionsPlaceholder).toBe('function');
+        });
+
+        it('should export renderAutoSuggestions', () => {
+            expect(renderAutoSuggestions).toBeDefined();
+            expect(typeof renderAutoSuggestions).toBe('function');
+        });
+    });
+
+    describe('squadRenderers.js', () => {
+        it('should export renderProjectedSquad', () => {
+            expect(renderProjectedSquad).toBeDefined();
+            expect(typeof renderProjectedSquad).toBe('function');
+        });
+    });
+
+    describe('playerModals.js', () => {
+        it('should export showSquadSelectionModal', () => {
+            expect(showSquadSelectionModal).toBeDefined();
+            expect(typeof showSquadSelectionModal).toBe('function');
+        });
+
+        it('should export showReplacementSelectionModal', () => {
+            expect(showReplacementSelectionModal).toBeDefined();
+            expect(typeof showReplacementSelectionModal).toBe('function');
+        });
+    });
+
+    describe('horizonManager.js', () => {
+        it('should export handlePlanningHorizonChange', () => {
+            expect(handlePlanningHorizonChange).toBeDefined();
+            expect(typeof handlePlanningHorizonChange).toBe('function');
+        });
+    });
+});


### PR DESCRIPTION
FIXES:
- Import isMobileDevice from renderMyTeamMobile.js (not utils.js)
- Verified with npm run build (passed)

NEW TEST INFRASTRUCTURE:
- Added pre-commit hook to run build checks
- Created import tests for Data Analysis modules (dataAnalysis.test.js)
- Created import tests for Team Builder modules (teamBuilder/modules.test.js)
- Created import tests for My Team Compact modules (myTeam/compact.test.js)

LESSONS LEARNED:
- node --check only validates syntax, NOT imports
- npm run build catches import/export errors
- Tests: 306 passed, build validated all imports