### PR TITLE
fix: scroll bounce back and add news indicators to Stats/rival modal

### DIFF
--- a/frontend/src/myTeam/leagueManagement.js
+++ b/frontend/src/myTeam/leagueManagement.js
@@ -28,7 +28,7 @@ export function renderLeaguesTab(teamData, myTeamState, loadLeagueStandingsForTa
     const useMobile = shouldUseMobileLayout();
 
     const html = `
-        <div style="display: ${useMobile ? 'flex' : 'grid'}; ${useMobile ? 'flex-direction: column;' : 'grid-template-columns: 300px 1fr;'} gap: 1.5rem; ${useMobile ? '' : 'height: calc(100vh - 300px);'}">
+        <div style="display: ${useMobile ? 'flex' : 'grid'}; ${useMobile ? 'flex-direction: column;' : 'grid-template-columns: 300px 1fr;'} gap: 1.5rem; ${useMobile ? '' : 'min-height: calc(100vh - 300px);'}">
             <!-- Left Sidebar: League Selection -->
             <div id="league-selection-sidebar" style="background: var(--bg-secondary); padding: ${useMobile ? '1rem' : '1.5rem'}; border-radius: 12px; ${useMobile ? '' : 'overflow-y: auto;'}">
                 <h3 style="font-size: 1rem; font-weight: 700; color: var(--text-primary); margin-bottom: 0.5rem;">

--- a/frontend/src/myTeam/teamComparison.js
+++ b/frontend/src/myTeam/teamComparison.js
@@ -151,12 +151,29 @@ function renderComparisonTeamColumn(picks, title, ownPlayerIds, otherPlayerIds, 
                     const bgColor = isDifferential ? `rgba(${accentColor === '#3b82f6' ? '59, 130, 246' : '239, 68, 68'}, 0.1)` :
                                     isShared ? 'rgba(34, 197, 94, 0.1)' : 'transparent';
 
+                    // Colored left border for players with news/injury
+                    let leftBorderStyle = 'none';
+                    if (player.news && player.news.trim() !== '') {
+                        const chanceOfPlaying = player.chance_of_playing_next_round;
+                        if (chanceOfPlaying !== null && chanceOfPlaying !== undefined) {
+                            if (chanceOfPlaying <= 25) {
+                                leftBorderStyle = '3px solid #ef4444'; // Red
+                            } else if (chanceOfPlaying <= 50) {
+                                leftBorderStyle = '3px solid #f97316'; // Orange
+                            } else {
+                                leftBorderStyle = '3px solid #fbbf24'; // Yellow
+                            }
+                        } else {
+                            leftBorderStyle = '3px solid #fbbf24'; // Yellow default for news
+                        }
+                    }
+
                     // Separator between starting 11 and bench
                     const separator = index === 11 ? `<div style="border-top: 2px solid var(--border-color); margin: 0.5rem 0;"></div>` : '';
 
                     return `
                         ${separator}
-                        <div style="background: ${bgColor}; padding: 0.5rem; border-radius: 6px; margin-bottom: 0.25rem; display: flex; justify-content: space-between; align-items: center; ${isBench ? 'opacity: 0.6;' : ''}">
+                        <div style="background: ${bgColor}; padding: 0.5rem; border-radius: 6px; margin-bottom: 0.25rem; display: flex; justify-content: space-between; align-items: center; border-left: ${leftBorderStyle}; ${isBench ? 'opacity: 0.6;' : ''}">
                             <div style="flex: 1;">
                                 <span style="font-weight: 600;">${escapeHtml(player.web_name)}</span>
                                 ${isCaptain ? ' <span style="color: var(--primary-color); font-weight: 700;">(C)</span>' : ''}

--- a/frontend/src/renderDataAnalysis.js
+++ b/frontend/src/renderDataAnalysis.js
@@ -849,10 +849,27 @@ function renderPositionSpecificTableMobile(players, contextColumn = 'total') {
             contextDivStyle = 'text-align: center; font-size: 0.7rem;';
         }
 
+        // Colored left border for players with news/injury
+        let leftBorderStyle = 'none';
+        if (player.news && player.news.trim() !== '') {
+            const chanceOfPlaying = player.chance_of_playing_next_round;
+            if (chanceOfPlaying !== null && chanceOfPlaying !== undefined) {
+                if (chanceOfPlaying <= 25) {
+                    leftBorderStyle = '3px solid #ef4444'; // Red
+                } else if (chanceOfPlaying <= 50) {
+                    leftBorderStyle = '3px solid #f97316'; // Orange
+                } else {
+                    leftBorderStyle = '3px solid #fbbf24'; // Yellow
+                }
+            } else {
+                leftBorderStyle = '3px solid #fbbf24'; // Yellow default for news
+            }
+        }
+
         html += `
             <div
                 class="player-row mobile-table-row"
-                style="grid-template-columns: 2fr 1.2fr 1fr 0.7fr 0.7fr 0.8fr; cursor: pointer; padding-bottom: 3px !important; padding-top: 3px !important;"
+                style="grid-template-columns: 2fr 1.2fr 1fr 0.7fr 0.7fr 0.8fr; cursor: pointer; padding-bottom: 3px !important; padding-top: 3px !important; border-left: ${leftBorderStyle};"
                 data-player-id="${player.id}"
             >
                 <div style="font-weight: 600; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">


### PR DESCRIPTION
- Changed League page container from fixed height to min-height
- Added colored left border for news/injury to Stats page player rows
- Added colored left border for news/injury to rival team modal rows
- Red (≤25%), Orange (26-50%), Yellow (51-75% or general news)