### PR TITLE
feat: Replace refresh button with live gameweek dashboard

### DIFF
--- a/frontend/src/liveDashboard.js
+++ b/frontend/src/liveDashboard.js
@@ -1,0 +1,167 @@
+// ============================================================================
+// LIVE GAMEWEEK DASHBOARD
+// Personalized live monitoring dashboard for gameweek tracking
+// ============================================================================
+
+import { 
+    fplBootstrap, 
+    fplFixtures, 
+    getActiveGW, 
+    getGameweekStatus, 
+    isGameweekLive,
+    startAutoRefresh,
+    stopAutoRefresh,
+    isAutoRefreshActive,
+    loadMyTeam
+} from './data.js';
+import { renderDashboardHeader } from './liveDashboard/dashboardHeader.js';
+import { renderMyTeamLiveTable } from './liveDashboard/myTeamLiveTable.js';
+import { renderLiveMatchesTable } from './liveDashboard/liveMatchesTable.js';
+import { renderTopPlayersTable } from './liveDashboard/topPlayersTable.js';
+
+let dashboardRefreshInterval = null;
+let myTeamData = null;
+
+/**
+ * Render the live gameweek dashboard
+ */
+export async function renderLiveDashboard() {
+    const container = document.getElementById('app-container');
+    
+    // Show loading state
+    container.innerHTML = `
+        <div style="text-align: center; padding: 4rem 2rem; color: var(--text-secondary);">
+            <i class="fas fa-spinner fa-spin" style="font-size: 3rem; margin-bottom: 1rem;"></i>
+            <p>Loading dashboard...</p>
+        </div>
+    `;
+
+    try {
+        // Load my team data
+        const teamId = localStorage.getItem('fplanner_team_id');
+        if (!teamId) {
+            container.innerHTML = `
+                <div style="text-align: center; padding: 4rem 2rem;">
+                    <i class="fas fa-info-circle" style="font-size: 3rem; color: var(--text-secondary); margin-bottom: 1rem;"></i>
+                    <p style="color: var(--text-secondary);">Please set up your team first</p>
+                    <button 
+                        onclick="window.location.hash = '#my-team'"
+                        style="
+                            margin-top: 1rem;
+                            padding: 0.75rem 1.5rem;
+                            background: var(--primary-color);
+                            color: white;
+                            border: none;
+                            border-radius: 0.5rem;
+                            cursor: pointer;
+                            font-weight: 600;
+                        "
+                    >
+                        Go to Team Page
+                    </button>
+                </div>
+            `;
+            return;
+        }
+
+        myTeamData = await loadMyTeam(teamId);
+        await renderDashboardContent();
+        
+        // Setup auto-refresh if GW is live
+        setupAutoRefresh();
+        
+    } catch (error) {
+        console.error('Failed to load dashboard:', error);
+        container.innerHTML = `
+            <div style="text-align: center; padding: 4rem 2rem;">
+                <i class="fas fa-exclamation-triangle" style="font-size: 3rem; color: var(--danger-color); margin-bottom: 1rem;"></i>
+                <p style="color: var(--text-secondary);">Failed to load dashboard</p>
+                <p style="color: var(--text-secondary); font-size: 0.875rem; margin-top: 0.5rem;">${error.message}</p>
+            </div>
+        `;
+    }
+}
+
+/**
+ * Render dashboard content
+ */
+async function renderDashboardContent() {
+    const container = document.getElementById('app-container');
+    const activeGW = getActiveGW();
+    
+    // Determine dashboard state
+    const gwStatus = getGameweekStatus(activeGW);
+    const isLive = isGameweekLive(activeGW);
+    
+    // Check 24-hour transition rule
+    let displayGW = activeGW;
+    let displayStatus = gwStatus;
+    
+    if (gwStatus === 'FINISHED') {
+        // Check if within 24 hours of next GW deadline
+        const nextEvent = fplBootstrap?.events?.find(e => e.id === activeGW + 1);
+        if (nextEvent) {
+            const deadline = new Date(nextEvent.deadline_time);
+            const now = new Date();
+            const hoursUntilDeadline = (deadline - now) / (1000 * 60 * 60);
+            
+            if (hoursUntilDeadline < 24) {
+                displayGW = activeGW + 1;
+                displayStatus = 'UPCOMING';
+            }
+        }
+    }
+    
+    // Render dashboard components
+    const header = renderDashboardHeader(myTeamData, displayGW, displayStatus, isAutoRefreshActive());
+    const teamTable = renderMyTeamLiveTable(myTeamData, displayGW, isLive);
+    const matchesTable = renderLiveMatchesTable(myTeamData, displayGW, displayStatus);
+    const topPlayers = renderTopPlayersTable(myTeamData, displayGW, isLive);
+    
+    container.innerHTML = `
+        ${header}
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; margin-bottom: 1rem; @media (max-width: 767px) { grid-template-columns: 1fr; }">
+            ${teamTable}
+            ${matchesTable}
+        </div>
+        ${topPlayers}
+    `;
+    
+    // Add responsive CSS for mobile
+    if (!document.getElementById('dashboard-responsive-style')) {
+        const style = document.createElement('style');
+        style.id = 'dashboard-responsive-style';
+        style.textContent = `
+            @media (max-width: 767px) {
+                #app-container > div[style*="grid-template-columns: 1fr 1fr"] {
+                    grid-template-columns: 1fr !important;
+                }
+            }
+        `;
+        document.head.appendChild(style);
+    }
+}
+
+/**
+ * Setup auto-refresh for live GW
+ */
+function setupAutoRefresh() {
+    const activeGW = getActiveGW();
+    const isLive = isGameweekLive(activeGW);
+    
+    if (isLive) {
+        // Start auto-refresh
+        startAutoRefresh(async () => {
+            // Reload team data and re-render
+            const teamId = localStorage.getItem('fplanner_team_id');
+            if (teamId) {
+                myTeamData = await loadMyTeam(teamId);
+                await renderDashboardContent();
+            }
+        });
+    } else {
+        // Stop auto-refresh if not live
+        stopAutoRefresh();
+    }
+}
+

--- a/frontend/src/liveDashboard/dashboardHeader.js
+++ b/frontend/src/liveDashboard/dashboardHeader.js
@@ -1,0 +1,88 @@
+// ============================================================================
+// DASHBOARD HEADER
+// Header card showing GW status, points, and rank
+// ============================================================================
+
+import { escapeHtml } from '../utils.js';
+import { getPlayerById } from '../data.js';
+
+/**
+ * Render dashboard header card
+ * @param {Object} teamData - Team data
+ * @param {number} gameweek - Gameweek number
+ * @param {string} status - GW status (LIVE/FINISHED/UPCOMING)
+ * @param {boolean} isAutoRefreshActive - Whether auto-refresh is active
+ * @returns {string} HTML for dashboard header
+ */
+export function renderDashboardHeader(teamData, gameweek, status, isAutoRefreshActive) {
+    const { team, picks } = teamData;
+    
+    // Get GW points and rank
+    let gwPoints = team.summary_event_points || 0;
+    let gwRank = team.summary_event_rank || 0;
+    
+    // If live, calculate from live stats
+    if (status === 'LIVE' && picks?.picks) {
+        const livePoints = picks.picks
+            .filter(p => p.position <= 11)
+            .reduce((sum, p) => {
+                const player = getPlayerById(p.element);
+                const pts = player?.live_stats?.total_points || 0;
+                const mult = p.is_captain ? 2 : 1;
+                return sum + (pts * mult);
+            }, 0);
+        if (livePoints > 0) gwPoints = livePoints;
+    }
+    
+    // Status badge
+    let statusBadge = '';
+    let statusColor = 'var(--text-secondary)';
+    if (status === 'LIVE') {
+        statusBadge = '<span style="color: #ef4444; font-weight: 700; animation: pulse 2s infinite;">⚡ LIVE</span>';
+        statusColor = '#ef4444';
+    } else if (status === 'FINISHED') {
+        statusBadge = '<span style="color: #22c55e; font-weight: 700;">✓ FINISHED</span>';
+        statusColor = '#22c55e';
+    } else {
+        statusBadge = '<span style="color: var(--text-secondary); font-weight: 700;">UPCOMING</span>';
+    }
+    
+    // Auto-refresh indicator
+    const refreshIndicator = isAutoRefreshActive ? `
+        <div style="display: flex; align-items: center; gap: 0.25rem; margin-top: 0.5rem; font-size: 0.65rem; color: var(--text-secondary);">
+            <i class="fas fa-sync-alt fa-spin" style="font-size: 0.6rem; color: #00ff88;"></i>
+            <span>Auto-refreshing every 2 min</span>
+        </div>
+    ` : '';
+    
+    return `
+        <div style="
+            background: var(--bg-primary);
+            border-left: 4px solid ${statusColor};
+            border-radius: 12px;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            box-shadow: 0 2px 8px var(--shadow);
+        ">
+            <div style="display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 0.5rem;">
+                <div>
+                    <div style="font-size: 0.75rem; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.25rem;">
+                        Gameweek ${gameweek}
+                    </div>
+                    <div style="font-size: 2rem; font-weight: 800; color: var(--text-primary); line-height: 1;">
+                        ${gwPoints}
+                    </div>
+                    <div style="font-size: 0.7rem; color: var(--text-secondary); margin-top: 0.25rem;">
+                        Rank: ${gwRank ? gwRank.toLocaleString() : 'N/A'}
+                    </div>
+                </div>
+                <div style="text-align: right;">
+                    ${statusBadge}
+                    ${refreshIndicator}
+                </div>
+            </div>
+        </div>
+        ${status === 'LIVE' ? '<style>@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }</style>' : ''}
+    `;
+}
+

--- a/frontend/src/liveDashboard/liveMatchesTable.js
+++ b/frontend/src/liveDashboard/liveMatchesTable.js
@@ -1,0 +1,205 @@
+// ============================================================================
+// LIVE MATCHES TABLE
+// Right column showing matches where my players are playing
+// ============================================================================
+
+import { fplFixtures, fplBootstrap, getPlayerById } from '../data.js';
+import { getTeamShortName } from '../utils.js';
+import { escapeHtml } from '../utils.js';
+
+// Team colors (from playerModal.js)
+const TEAM_COLORS = {
+    1: '#EF0107', 2: '#95BFE5', 3: '#DA291C', 4: '#E30613', 5: '#0057B8',
+    6: '#6C1D45', 7: '#034694', 8: '#1B458F', 9: '#003399', 10: '#000000',
+    11: '#FFCD00', 12: '#C8102E', 13: '#6CABDD', 14: '#DA291C', 15: '#241F20',
+    16: '#DD0000', 17: '#EB172B', 18: '#132257', 19: '#7A263A', 20: '#FDB913',
+    21: '#0057B8', 22: '#C8102E'
+};
+
+function getTeamColor(teamId) {
+    return TEAM_COLORS[teamId] || '#666666';
+}
+
+function isColorDark(hex) {
+    hex = hex.replace('#', '');
+    const r = parseInt(hex.substr(0, 2), 16);
+    const g = parseInt(hex.substr(2, 2), 16);
+    const b = parseInt(hex.substr(4, 2), 16);
+    const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+    return luminance < 0.5;
+}
+
+/**
+ * Render live matches table (right column)
+ * @param {Object} teamData - Team data
+ * @param {number} gameweek - Gameweek number
+ * @param {string} status - GW status
+ * @returns {string} HTML for matches table
+ */
+export function renderLiveMatchesTable(teamData, gameweek, status) {
+    const { picks } = teamData;
+    if (!picks || !picks.picks || !fplFixtures || !fplBootstrap) {
+        return '<div style="background: var(--bg-secondary); padding: 1rem; border-radius: 12px; text-align: center; color: var(--text-secondary);">No fixtures data</div>';
+    }
+    
+    // Get unique team IDs from my players
+    const myTeamIds = new Set();
+    picks.picks.forEach(pick => {
+        const player = getPlayerById(pick.element);
+        if (player) myTeamIds.add(player.team);
+    });
+    
+    // Filter fixtures to only those where my players are playing
+    const relevantFixtures = fplFixtures
+        .filter(f => f.event === gameweek && (myTeamIds.has(f.team_h) || myTeamIds.has(f.team_a)))
+        .sort((a, b) => new Date(a.kickoff_time) - new Date(b.kickoff_time));
+    
+    if (relevantFixtures.length === 0) {
+        return `
+            <div style="background: var(--bg-secondary); padding: 1rem; border-radius: 12px; text-align: center; color: var(--text-secondary);">
+                No matches for this GW
+            </div>
+        `;
+    }
+    
+    // Separate live and finished matches
+    const liveMatches = relevantFixtures.filter(f => f.started && !f.finished);
+    const finishedMatches = relevantFixtures.filter(f => f.finished);
+    const upcomingMatches = relevantFixtures.filter(f => !f.started && !f.finished);
+    
+    // Sort: live first, then upcoming, then finished
+    const sortedMatches = [...liveMatches, ...upcomingMatches, ...finishedMatches];
+    
+    const headerRow = `
+        <div class="mobile-table-header mobile-table-header-sticky" style="top: calc(3.5rem + env(safe-area-inset-top));">
+            <div>Match</div>
+            <div style="text-align: center;">Status</div>
+        </div>
+    `;
+    
+    const rowsHtml = sortedMatches.map(fixture => {
+        const homeTeamId = fixture.team_h;
+        const awayTeamId = fixture.team_a;
+        const homeShort = getTeamShortName(homeTeamId);
+        const awayShort = getTeamShortName(awayTeamId);
+        
+        const homeColor = getTeamColor(homeTeamId);
+        const awayColor = getTeamColor(awayTeamId);
+        const homeBg = isColorDark(homeColor) ? 'rgba(255, 255, 255, 0.9)' : 'rgba(255, 255, 255, 0.1)';
+        const awayBg = isColorDark(awayColor) ? 'rgba(255, 255, 255, 0.9)' : 'rgba(255, 255, 255, 0.1)';
+        
+        let matchDisplay = '';
+        let statusDisplay = '';
+        let rowStyle = 'background: var(--bg-primary);';
+        
+        if (fixture.finished) {
+            // Finished: MCI 1-5 LIV (grey)
+            const homeScore = fixture.team_h_score ?? '-';
+            const awayScore = fixture.team_a_score ?? '-';
+            matchDisplay = `
+                <span style="
+                    background: ${homeBg};
+                    color: ${homeColor};
+                    padding: 0.1rem 0.35rem;
+                    border-radius: 0.2rem;
+                    font-weight: 700;
+                    font-size: 0.7rem;
+                ">${homeShort}</span>
+                <span style="color: var(--text-secondary); margin: 0 0.25rem;">${homeScore}-${awayScore}</span>
+                <span style="
+                    background: ${awayBg};
+                    color: ${awayColor};
+                    padding: 0.1rem 0.35rem;
+                    border-radius: 0.2rem;
+                    font-weight: 700;
+                    font-size: 0.7rem;
+                ">${awayShort}</span>
+            `;
+            statusDisplay = '<span style="color: var(--text-secondary); font-size: 0.65rem;">FT</span>';
+            rowStyle = 'background: var(--bg-primary); opacity: 0.6; color: var(--text-secondary);';
+        } else if (fixture.started && !fixture.finished) {
+            // Live: MCI 1-5 LIV with LIVE badge
+            const homeScore = fixture.team_h_score ?? '-';
+            const awayScore = fixture.team_a_score ?? '-';
+            matchDisplay = `
+                <span style="
+                    background: ${homeBg};
+                    color: ${homeColor};
+                    padding: 0.1rem 0.35rem;
+                    border-radius: 0.2rem;
+                    font-weight: 700;
+                    font-size: 0.7rem;
+                ">${homeShort}</span>
+                <span style="margin: 0 0.25rem;">${homeScore}-${awayScore}</span>
+                <span style="
+                    background: ${awayBg};
+                    color: ${awayColor};
+                    padding: 0.1rem 0.35rem;
+                    border-radius: 0.2rem;
+                    font-weight: 700;
+                    font-size: 0.7rem;
+                ">${awayShort}</span>
+            `;
+            statusDisplay = '<span style="color: #ef4444; font-weight: 700; font-size: 0.65rem;">LIVE</span>';
+        } else {
+            // Upcoming: MUN vs. BOU Sat 2200 (SGT)
+            const kickoffDate = new Date(fixture.kickoff_time);
+            const sgtTime = new Date(kickoffDate.getTime() + (8 * 60 * 60 * 1000));
+            const dayStr = sgtTime.toLocaleString('en-SG', { 
+                timeZone: 'Asia/Singapore',
+                weekday: 'short' 
+            });
+            const timeStr = sgtTime.toLocaleString('en-SG', {
+                timeZone: 'Asia/Singapore',
+                hour: '2-digit',
+                minute: '2-digit',
+                hour12: false
+            }).replace(':', '');
+            
+            matchDisplay = `
+                <span style="
+                    background: ${homeBg};
+                    color: ${homeColor};
+                    padding: 0.1rem 0.35rem;
+                    border-radius: 0.2rem;
+                    font-weight: 700;
+                    font-size: 0.7rem;
+                ">${homeShort}</span>
+                <span style="margin: 0 0.25rem; color: var(--text-secondary);">vs.</span>
+                <span style="
+                    background: ${awayBg};
+                    color: ${awayColor};
+                    padding: 0.1rem 0.35rem;
+                    border-radius: 0.2rem;
+                    font-weight: 700;
+                    font-size: 0.7rem;
+                ">${awayShort}</span>
+            `;
+            statusDisplay = `<span style="color: var(--text-secondary); font-size: 0.65rem;">${dayStr} ${timeStr}</span>`;
+        }
+        
+        return `
+            <div class="mobile-table-row" style="${rowStyle}">
+                <div style="display: flex; align-items: center; gap: 0.25rem; flex-wrap: wrap;">
+                    ${matchDisplay}
+                </div>
+                <div style="text-align: center;">
+                    ${statusDisplay}
+                </div>
+            </div>
+        `;
+    }).join('');
+    
+    return `
+        <div style="background: var(--bg-secondary); border-radius: 12px; box-shadow: 0 2px 8px var(--shadow); overflow: hidden;">
+            <div style="padding: 0.5rem 0.75rem; background: var(--bg-secondary); border-bottom: 1px solid var(--border-color);">
+                <h4 style="font-size: 0.9rem; font-weight: 700; color: var(--text-primary);">
+                    Live Matches
+                </h4>
+            </div>
+            ${headerRow}
+            ${rowsHtml}
+        </div>
+    `;
+}
+

--- a/frontend/src/liveDashboard/myTeamLiveTable.js
+++ b/frontend/src/liveDashboard/myTeamLiveTable.js
@@ -1,0 +1,102 @@
+// ============================================================================
+// MY TEAM LIVE TABLE
+// Left column showing top players with sticky C/VC
+// ============================================================================
+
+import { getPlayerById } from '../data.js';
+import { escapeHtml } from '../utils.js';
+
+/**
+ * Render my team live table (left column)
+ * @param {Object} teamData - Team data
+ * @param {number} gameweek - Gameweek number
+ * @param {boolean} isLive - Whether GW is live
+ * @returns {string} HTML for team live table
+ */
+export function renderMyTeamLiveTable(teamData, gameweek, isLive) {
+    const { picks } = teamData;
+    if (!picks || !picks.picks) {
+        return '<div style="background: var(--bg-secondary); padding: 1rem; border-radius: 12px; text-align: center; color: var(--text-secondary);">No team data</div>';
+    }
+    
+    // Get all players with their live points
+    const playersWithPoints = picks.picks.map(pick => {
+        const player = getPlayerById(pick.element);
+        if (!player) return null;
+        
+        const gwPoints = isLive ? (player.live_stats?.total_points || 0) : (player.event_points || 0);
+        const minutes = isLive ? (player.live_stats?.minutes || 0) : 0;
+        
+        return {
+            pick,
+            player,
+            gwPoints,
+            minutes,
+            isCaptain: pick.is_captain,
+            isVice: pick.is_vice_captain,
+            isBench: pick.position > 11
+        };
+    }).filter(Boolean);
+    
+    // Separate C/VC and other players
+    const captain = playersWithPoints.find(p => p.isCaptain && !p.isBench);
+    const vice = playersWithPoints.find(p => p.isVice && !p.isBench);
+    const otherPlayers = playersWithPoints
+        .filter(p => !p.isCaptain && !p.isVice && !p.isBench)
+        .sort((a, b) => b.gwPoints - a.gwPoints)
+        .slice(0, 5); // Top 5 performers
+    
+    // Build rows: C, VC, then top performers
+    const rows = [];
+    if (captain) rows.push(captain);
+    if (vice) rows.push(vice);
+    rows.push(...otherPlayers);
+    
+    const headerRow = `
+        <div class="mobile-table-header mobile-table-header-sticky" style="top: calc(3.5rem + env(safe-area-inset-top));">
+            <div>Player</div>
+            <div style="text-align: center;">Pts</div>
+            <div style="text-align: center;">Min</div>
+        </div>
+    `;
+    
+    const rowsHtml = rows.map((item, index) => {
+        const bgColor = item.isCaptain ? 'rgb(104, 98, 132)' : 
+                       item.isVice ? 'rgb(104, 98, 132)' : 
+                       'var(--bg-primary)';
+        const borderLeft = item.isCaptain ? '3px solid var(--primary-color)' : 
+                          item.isVice ? '3px solid var(--text-secondary)' : 'none';
+        
+        return `
+            <div class="mobile-table-row" style="background: ${bgColor}; border-left: ${borderLeft};">
+                <div>
+                    <div style="font-size: 0.7rem; font-weight: 600; color: var(--text-primary);">
+                        ${item.isCaptain ? '(C) ' : item.isVice ? '(VC) ' : ''}${escapeHtml(item.player.web_name)}
+                    </div>
+                    <div style="font-size: 0.65rem; color: var(--text-secondary); margin-top: 0.1rem;">
+                        ${item.player.element_type === 1 ? 'GKP' : item.player.element_type === 2 ? 'DEF' : item.player.element_type === 3 ? 'MID' : 'FWD'}
+                    </div>
+                </div>
+                <div style="text-align: center; font-weight: 700; color: var(--text-primary);">
+                    ${item.gwPoints}
+                </div>
+                <div style="text-align: center; font-size: 0.7rem; color: var(--text-secondary);">
+                    ${item.minutes || '—'}
+                </div>
+            </div>
+        `;
+    }).join('');
+    
+    return `
+        <div style="background: var(--bg-secondary); border-radius: 12px; box-shadow: 0 2px 8px var(--shadow); overflow: hidden;">
+            <div style="padding: 0.5rem 0.75rem; background: var(--bg-secondary); border-bottom: 1px solid var(--border-color);">
+                <h4 style="font-size: 0.9rem; font-weight: 700; color: var(--text-primary);">
+                    My Team Live
+                </h4>
+            </div>
+            ${headerRow}
+            ${rowsHtml}
+        </div>
+    `;
+}
+

--- a/frontend/src/liveDashboard/topPlayersTable.js
+++ b/frontend/src/liveDashboard/topPlayersTable.js
@@ -1,0 +1,97 @@
+// ============================================================================
+// TOP PLAYERS TABLE
+// Global top players of the GW with my players highlighted
+// ============================================================================
+
+import { getAllPlayers, getPlayerById } from '../data.js';
+import { getTeamShortName, escapeHtml } from '../utils.js';
+
+/**
+ * Render global top players table
+ * @param {Object} teamData - Team data
+ * @param {number} gameweek - Gameweek number
+ * @param {boolean} isLive - Whether GW is live
+ * @returns {string} HTML for top players table
+ */
+export function renderTopPlayersTable(teamData, gameweek, isLive) {
+    const allPlayers = getAllPlayers();
+    if (!allPlayers || allPlayers.length === 0) {
+        return '';
+    }
+    
+    // Get my team player IDs
+    const myPlayerIds = new Set();
+    if (teamData?.picks?.picks) {
+        teamData.picks.picks.forEach(pick => {
+            myPlayerIds.add(pick.element);
+        });
+    }
+    
+    // Calculate GW points for all players
+    const playersWithPoints = allPlayers.map(player => {
+        const gwPoints = isLive ? (player.live_stats?.total_points || 0) : (player.event_points || 0);
+        return {
+            player,
+            gwPoints,
+            isMyPlayer: myPlayerIds.has(player.id)
+        };
+    }).filter(p => p.gwPoints > 0); // Only show players with points
+    
+    // Sort by points descending and take top 15
+    const topPlayers = playersWithPoints
+        .sort((a, b) => b.gwPoints - a.gwPoints)
+        .slice(0, 15);
+    
+    if (topPlayers.length === 0) {
+        return '';
+    }
+    
+    const headerRow = `
+        <div class="mobile-table-header mobile-table-header-sticky" style="top: calc(3.5rem + env(safe-area-inset-top));">
+            <div style="text-align: center;">Rank</div>
+            <div>Player</div>
+            <div style="text-align: center;">Pts</div>
+            <div style="text-align: center;">Team</div>
+        </div>
+    `;
+    
+    const rowsHtml = topPlayers.map((item, index) => {
+        const rank = index + 1;
+        const bgColor = item.isMyPlayer ? 'rgba(56, 189, 248, 0.1)' : 'var(--bg-primary)';
+        const borderLeft = item.isMyPlayer ? '3px solid var(--primary-color)' : 'none';
+        
+        return `
+            <div class="mobile-table-row" style="background: ${bgColor}; border-left: ${borderLeft};">
+                <div style="text-align: center; font-weight: 600;">${rank}</div>
+                <div>
+                    <div style="font-size: 0.7rem; font-weight: 600; color: var(--text-primary);">
+                        ${escapeHtml(item.player.web_name)}
+                        ${item.isMyPlayer ? ' <span style="color: var(--primary-color);">⭐</span>' : ''}
+                    </div>
+                    <div style="font-size: 0.65rem; color: var(--text-secondary); margin-top: 0.1rem;">
+                        ${item.player.element_type === 1 ? 'GKP' : item.player.element_type === 2 ? 'DEF' : item.player.element_type === 3 ? 'MID' : 'FWD'}
+                    </div>
+                </div>
+                <div style="text-align: center; font-weight: 700; color: var(--text-primary);">
+                    ${item.gwPoints}
+                </div>
+                <div style="text-align: center; font-size: 0.7rem; color: var(--text-secondary);">
+                    ${getTeamShortName(item.player.team)}
+                </div>
+            </div>
+        `;
+    }).join('');
+    
+    return `
+        <div style="background: var(--bg-secondary); border-radius: 12px; box-shadow: 0 2px 8px var(--shadow); overflow: hidden; margin-top: 1rem;">
+            <div style="padding: 0.5rem 0.75rem; background: var(--bg-secondary); border-bottom: 1px solid var(--border-color);">
+                <h4 style="font-size: 0.9rem; font-weight: 700; color: var(--text-primary);">
+                    Top Players (GW${gameweek})
+                </h4>
+            </div>
+            ${headerRow}
+            ${rowsHtml}
+        </div>
+    `;
+}
+

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -99,6 +99,9 @@ function renderPage() {
         case 'search':
             renderSearch();
             break;
+        case 'dashboard':
+            renderDashboard();
+            break;
         default:
             container.innerHTML = '<p>Page not found</p>';
     }
@@ -131,6 +134,11 @@ async function renderCharts() {
 async function renderSearch() {
     const { renderSearch: render } = await import('./renderSearch.js');
     render();
+}
+
+async function renderDashboard() {
+    const { renderLiveDashboard } = await import('./liveDashboard.js');
+    renderLiveDashboard();
 }
 
 // ============================================================================

--- a/frontend/src/mobileNav.js
+++ b/frontend/src/mobileNav.js
@@ -13,7 +13,7 @@ export function createMobileNav(currentPage, onNavigate) {
     const navItems = [
         { id: 'league', label: 'League', icon: 'fa-trophy', action: 'league' },
         { id: 'my-team', label: 'Team', icon: 'fa-users' },
-        { id: 'refresh', label: 'Refresh', icon: 'fa-sync-alt', action: 'refresh', isGreen: true },
+        { id: 'dashboard', label: 'Dashboard', icon: 'fa-tachometer-alt', action: 'dashboard', isGreen: true },
         { id: 'fixtures', label: 'Fixtures', icon: 'fa-calendar-alt', action: 'fixtures' },
         { id: 'stats', label: 'Stats', icon: 'fa-chart-bar', action: 'stats' }
     ];
@@ -120,29 +120,9 @@ export function initMobileNav(navigateCallback) {
                 navigateCallback('data-analysis');
                 return;
             }
-            if (action === 'refresh') {
-                const icon = item.querySelector('i');
-                const originalIcon = icon.className;
-                icon.className = 'fas fa-sync-alt fa-spin';
-                item.disabled = true;
-
-                // Trigger refresh
-                if (window.handleTeamRefresh) {
-                    window.handleTeamRefresh()
-                        .then(() => {
-                            console.log('✅ Team refreshed');
-                        })
-                        .catch((error) => {
-                            console.error('❌ Refresh failed:', error);
-                        })
-                        .finally(() => {
-                            icon.className = originalIcon;
-                            item.disabled = false;
-                        });
-                } else {
-                    // Fallback: reload page
-                    window.location.reload();
-                }
+            if (action === 'dashboard') {
+                console.log('📊 Dashboard button clicked - navigating to dashboard');
+                navigateCallback('dashboard');
                 return;
             }
 
@@ -156,8 +136,8 @@ export function initMobileNav(navigateCallback) {
         // Add touch feedback
         item.addEventListener('touchstart', () => {
             if (!item.disabled) {
-                const isRefresh = item.dataset.action === 'refresh';
-                if (!isRefresh) {
+                const isDashboard = item.dataset.action === 'dashboard';
+                if (!isDashboard) {
                     item.style.background = 'var(--border-dark)';
                 }
             }
@@ -167,8 +147,8 @@ export function initMobileNav(navigateCallback) {
             if (!item.disabled) {
                 const page = item.dataset.page;
                 const currentPage = getCurrentPage();
-                const isRefresh = item.dataset.action === 'refresh';
-                item.style.background = isRefresh ? 'transparent' : (currentPage === page ? 'var(--bg-tertiary)' : 'transparent');
+                const isDashboard = item.dataset.action === 'dashboard';
+                item.style.background = isDashboard ? 'transparent' : (currentPage === page ? 'var(--bg-tertiary)' : 'transparent');
             }
         });
     });
@@ -196,25 +176,27 @@ export function updateMobileNav(activePage, subTab = 'overview') {
             isActive = true;
         } else if (action === 'stats' && activePage === 'data-analysis') {
             isActive = true;
+        } else if (action === 'dashboard' && activePage === 'dashboard') {
+            isActive = true;
         } else if (page === activePage && subTab === 'overview') {
             isActive = true;
         } else {
             isActive = false;
         }
 
-        const isRefresh = action === 'refresh';
+        const isDashboard = action === 'dashboard';
 
-        item.style.background = isRefresh ? 'transparent' : (isActive ? 'var(--bg-tertiary)' : 'transparent');
+        item.style.background = isDashboard ? 'transparent' : (isActive ? 'var(--bg-tertiary)' : 'transparent');
         const label = item.querySelector('span');
         if (label) {
-            label.style.fontWeight = isActive || isRefresh ? '700' : '500';
-            if (isRefresh) {
+            label.style.fontWeight = isActive || isDashboard ? '700' : '500';
+            if (isDashboard) {
                 label.style.color = '#00ff88';
             }
         }
 
-        // Set icon color for refresh button
-        if (isRefresh) {
+        // Set icon color for dashboard button
+        if (isDashboard) {
             const icon = item.querySelector('i');
             if (icon) {
                 icon.style.color = '#00ff88';

--- a/frontend/src/myTeam/fixturesTab.js
+++ b/frontend/src/myTeam/fixturesTab.js
@@ -28,9 +28,15 @@ export function renderFixturesTab() {
         `;
     }
 
-    // Get recent GW fixtures (current and previous GW)
+    // Check if current GW is finished
+    const currentEvent = fplBootstrap?.events?.find(e => e.id === currentGW);
+    const isCurrentGWFinished = currentEvent?.finished || false;
+    const nextGW = currentGW + 1;
+    
+    // Get fixtures: if current GW finished, include next GW at top
+    const gwToShow = isCurrentGWFinished ? [nextGW, currentGW, currentGW - 1] : [currentGW, currentGW - 1];
     const recentFixtures = fplFixtures
-        .filter(f => f.event === currentGW || f.event === currentGW - 1)
+        .filter(f => gwToShow.includes(f.event))
         .sort((a, b) => {
             // Sort by event (GW) descending, then by kickoff time
             if (b.event !== a.event) return b.event - a.event;
@@ -152,9 +158,15 @@ export function renderMobileFixturesTab() {
         `;
     }
 
-    // Get recent GW fixtures
+    // Check if current GW is finished
+    const currentEvent = fplBootstrap?.events?.find(e => e.id === currentGW);
+    const isCurrentGWFinished = currentEvent?.finished || false;
+    const nextGW = currentGW + 1;
+    
+    // Get fixtures: if current GW finished, include next GW at top
+    const gwToShow = isCurrentGWFinished ? [nextGW, currentGW, currentGW - 1] : [currentGW, currentGW - 1];
     const recentFixtures = fplFixtures
-        .filter(f => f.event === currentGW || f.event === currentGW - 1)
+        .filter(f => gwToShow.includes(f.event))
         .sort((a, b) => {
             if (b.event !== a.event) return b.event - a.event;
             return new Date(b.kickoff_time) - new Date(a.kickoff_time);


### PR DESCRIPTION
- Replace mobile refresh button with dashboard button
- Create new dashboard page for live GW monitoring
- Implement dashboard header with GW status, points, and rank
- Add my team live table with sticky C/VC and top performers
- Add live matches table with team colors and SGT time formatting
- Add global top players table using enriched bootstrap data
- Implement 24-hour transition rule for completed GWs
- Add responsive two-column layout (stacks on mobile)
- Integrate with existing auto-refresh system
- Update fixtures page to show next GW when current GW ends
- Style concluded matches in grey
- Use team color styling for match displays