### PR TITLE
fix: Dashboard styling and 24h transition logic

### DIFF
--- a/frontend/src/liveDashboard.js
+++ b/frontend/src/liveDashboard.js
@@ -93,22 +93,21 @@ async function renderDashboardContent() {
     const gwStatus = getGameweekStatus(activeGW);
     const isLive = isGameweekLive(activeGW);
     
-    // Check 24-hour transition rule
+    // Check 24-hour transition rule (use same logic as countdown timer)
     let displayGW = activeGW;
     let displayStatus = gwStatus;
     
-    if (gwStatus === 'FINISHED') {
-        // Check if within 24 hours of next GW deadline
-        const nextEvent = fplBootstrap?.events?.find(e => e.id === activeGW + 1);
-        if (nextEvent) {
-            const deadline = new Date(nextEvent.deadline_time);
-            const now = new Date();
-            const hoursUntilDeadline = (deadline - now) / (1000 * 60 * 60);
-            
-            if (hoursUntilDeadline < 24) {
-                displayGW = activeGW + 1;
-                displayStatus = 'UPCOMING';
-            }
+    // Get next event (the one with is_next flag, same as countdown timer)
+    const nextEvent = fplBootstrap?.events?.find(e => e.is_next);
+    if (nextEvent) {
+        const deadline = new Date(nextEvent.deadline_time);
+        const now = new Date();
+        const hoursUntilDeadline = (deadline - now) / (1000 * 60 * 60);
+        
+        // If within 24 hours of next GW deadline, show next GW
+        if (hoursUntilDeadline < 24 && hoursUntilDeadline > 0) {
+            displayGW = nextEvent.id;
+            displayStatus = 'UPCOMING';
         }
     }
     
@@ -120,7 +119,7 @@ async function renderDashboardContent() {
     
     container.innerHTML = `
         ${header}
-        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; margin-bottom: 1rem; @media (max-width: 767px) { grid-template-columns: 1fr; }">
+        <div id="dashboard-two-column" style="display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; margin-bottom: 1rem;">
             ${teamTable}
             ${matchesTable}
         </div>
@@ -133,7 +132,7 @@ async function renderDashboardContent() {
         style.id = 'dashboard-responsive-style';
         style.textContent = `
             @media (max-width: 767px) {
-                #app-container > div[style*="grid-template-columns: 1fr 1fr"] {
+                #dashboard-two-column {
                     grid-template-columns: 1fr !important;
                 }
             }

--- a/frontend/src/liveDashboard/liveMatchesTable.js
+++ b/frontend/src/liveDashboard/liveMatchesTable.js
@@ -71,7 +71,7 @@ export function renderLiveMatchesTable(teamData, gameweek, status) {
     const sortedMatches = [...liveMatches, ...upcomingMatches, ...finishedMatches];
     
     const headerRow = `
-        <div class="mobile-table-header mobile-table-header-sticky" style="top: calc(3.5rem + env(safe-area-inset-top));">
+        <div class="mobile-table-header mobile-table-header-sticky mobile-table-dashboard-matches" style="top: calc(3.5rem + env(safe-area-inset-top));">
             <div>Match</div>
             <div style="text-align: center;">Status</div>
         </div>
@@ -179,7 +179,7 @@ export function renderLiveMatchesTable(teamData, gameweek, status) {
         }
         
         return `
-            <div class="mobile-table-row" style="${rowStyle}">
+            <div class="mobile-table-row mobile-table-dashboard-matches" style="${rowStyle}">
                 <div style="display: flex; align-items: center; gap: 0.25rem; flex-wrap: wrap;">
                     ${matchDisplay}
                 </div>

--- a/frontend/src/liveDashboard/myTeamLiveTable.js
+++ b/frontend/src/liveDashboard/myTeamLiveTable.js
@@ -53,7 +53,7 @@ export function renderMyTeamLiveTable(teamData, gameweek, isLive) {
     rows.push(...otherPlayers);
     
     const headerRow = `
-        <div class="mobile-table-header mobile-table-header-sticky" style="top: calc(3.5rem + env(safe-area-inset-top));">
+        <div class="mobile-table-header mobile-table-header-sticky mobile-table-dashboard-team" style="top: calc(3.5rem + env(safe-area-inset-top));">
             <div>Player</div>
             <div style="text-align: center;">Pts</div>
             <div style="text-align: center;">Min</div>
@@ -68,7 +68,7 @@ export function renderMyTeamLiveTable(teamData, gameweek, isLive) {
                           item.isVice ? '3px solid var(--text-secondary)' : 'none';
         
         return `
-            <div class="mobile-table-row" style="background: ${bgColor}; border-left: ${borderLeft};">
+            <div class="mobile-table-row mobile-table-dashboard-team" style="background: ${bgColor}; border-left: ${borderLeft};">
                 <div>
                     <div style="font-size: 0.7rem; font-weight: 600; color: var(--text-primary);">
                         ${item.isCaptain ? '(C) ' : item.isVice ? '(VC) ' : ''}${escapeHtml(item.player.web_name)}

--- a/frontend/src/liveDashboard/topPlayersTable.js
+++ b/frontend/src/liveDashboard/topPlayersTable.js
@@ -47,7 +47,7 @@ export function renderTopPlayersTable(teamData, gameweek, isLive) {
     }
     
     const headerRow = `
-        <div class="mobile-table-header mobile-table-header-sticky" style="top: calc(3.5rem + env(safe-area-inset-top));">
+        <div class="mobile-table-header mobile-table-header-sticky mobile-table-dashboard-top" style="top: calc(3.5rem + env(safe-area-inset-top));">
             <div style="text-align: center;">Rank</div>
             <div>Player</div>
             <div style="text-align: center;">Pts</div>
@@ -61,7 +61,7 @@ export function renderTopPlayersTable(teamData, gameweek, isLive) {
         const borderLeft = item.isMyPlayer ? '3px solid var(--primary-color)' : 'none';
         
         return `
-            <div class="mobile-table-row" style="background: ${bgColor}; border-left: ${borderLeft};">
+            <div class="mobile-table-row mobile-table-dashboard-top" style="background: ${bgColor}; border-left: ${borderLeft};">
                 <div style="text-align: center; font-weight: 600;">${rank}</div>
                 <div>
                     <div style="font-size: 0.7rem; font-weight: 600; color: var(--text-primary);">

--- a/frontend/src/myTeam/fixturesTab.js
+++ b/frontend/src/myTeam/fixturesTab.js
@@ -38,9 +38,9 @@ export function renderFixturesTab() {
     const recentFixtures = fplFixtures
         .filter(f => gwToShow.includes(f.event))
         .sort((a, b) => {
-            // Sort by event (GW) descending, then by kickoff time
+            // Sort by event (GW) descending, then by kickoff time ascending (chronological)
             if (b.event !== a.event) return b.event - a.event;
-            return new Date(b.kickoff_time) - new Date(a.kickoff_time);
+            return new Date(a.kickoff_time) - new Date(b.kickoff_time);
         });
 
     // Group fixtures by GW
@@ -168,8 +168,9 @@ export function renderMobileFixturesTab() {
     const recentFixtures = fplFixtures
         .filter(f => gwToShow.includes(f.event))
         .sort((a, b) => {
+            // Sort by event (GW) descending, then by kickoff time ascending (chronological)
             if (b.event !== a.event) return b.event - a.event;
-            return new Date(b.kickoff_time) - new Date(a.kickoff_time);
+            return new Date(a.kickoff_time) - new Date(b.kickoff_time);
         });
 
     // Group fixtures by GW

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -369,6 +369,18 @@ body {
     grid-template-columns: 0.7fr 2fr 0.7fr 0.8fr 0.8fr;
   }
 
+  .mobile-table-dashboard-team {
+    grid-template-columns: 2fr 0.8fr 0.8fr;
+  }
+
+  .mobile-table-dashboard-matches {
+    grid-template-columns: 2fr 0.8fr;
+  }
+
+  .mobile-table-dashboard-top {
+    grid-template-columns: 0.7fr 2fr 0.8fr 0.8fr;
+  }
+
   .mobile-table-fixtures {
     grid-template-columns: 0.8fr 2fr 1fr 2fr 0.6fr;
   }


### PR DESCRIPTION
- Add proper grid layout classes to dashboard tables (mobile-table-dashboard-*)
- Fix two-column layout to properly split 50/50 with proper ID selector
- Fix 24-hour transition logic to use countdown timer logic (is_next event)
- Fix fixtures page to sort chronologically within each GW