### PR TITLE
fix: Dashboard header card, layout, and Top Performers table

### DIFF
--- a/frontend/src/liveDashboard.js
+++ b/frontend/src/liveDashboard.js
@@ -119,26 +119,12 @@ async function renderDashboardContent() {
     
     container.innerHTML = `
         ${header}
-        <div id="dashboard-two-column" style="display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; margin-bottom: 1rem;">
+        <div id="dashboard-two-column" style="display: grid; grid-template-columns: 3fr 1fr; gap: 0.75rem; margin-bottom: 1rem;">
             ${teamTable}
             ${matchesTable}
         </div>
         ${topPlayers}
     `;
-    
-    // Add responsive CSS for mobile
-    if (!document.getElementById('dashboard-responsive-style')) {
-        const style = document.createElement('style');
-        style.id = 'dashboard-responsive-style';
-        style.textContent = `
-            @media (max-width: 767px) {
-                #dashboard-two-column {
-                    grid-template-columns: 1fr !important;
-                }
-            }
-        `;
-        document.head.appendChild(style);
-    }
 }
 
 /**

--- a/frontend/src/liveDashboard/topPlayersTable.js
+++ b/frontend/src/liveDashboard/topPlayersTable.js
@@ -1,13 +1,23 @@
 // ============================================================================
 // TOP PLAYERS TABLE
 // Global top players of the GW with my players highlighted
+// Uses exact same styling as stats page Top Performers table
 // ============================================================================
 
 import { getAllPlayers, getPlayerById } from '../data.js';
-import { getTeamShortName, escapeHtml } from '../utils.js';
+import { 
+    escapeHtml, 
+    formatDecimal, 
+    getPtsHeatmap, 
+    getFormHeatmap, 
+    getHeatmapStyle 
+} from '../utils.js';
+import { getGWOpponent, getMatchStatus } from '../fixtures.js';
+import { getDifficultyClass } from '../utils.js';
+import { getActiveGW } from '../data.js';
 
 /**
- * Render global top players table
+ * Render global top players table (GW Top Performers)
  * @param {Object} teamData - Team data
  * @param {number} gameweek - Gameweek number
  * @param {boolean} isLive - Whether GW is live
@@ -18,6 +28,8 @@ export function renderTopPlayersTable(teamData, gameweek, isLive) {
     if (!allPlayers || allPlayers.length === 0) {
         return '';
     }
+    
+    const currentGW = getActiveGW();
     
     // Get my team player IDs
     const myPlayerIds = new Set();
@@ -37,7 +49,7 @@ export function renderTopPlayersTable(teamData, gameweek, isLive) {
         };
     }).filter(p => p.gwPoints > 0); // Only show players with points
     
-    // Sort by points descending and take top 15
+    // Sort by GW points descending and take top 15
     const topPlayers = playersWithPoints
         .sort((a, b) => b.gwPoints - a.gwPoints)
         .slice(0, 15);
@@ -46,52 +58,119 @@ export function renderTopPlayersTable(teamData, gameweek, isLive) {
         return '';
     }
     
-    const headerRow = `
-        <div class="mobile-table-header mobile-table-header-sticky mobile-table-dashboard-top" style="top: calc(3.5rem + env(safe-area-inset-top));">
-            <div style="text-align: center;">Rank</div>
-            <div>Player</div>
-            <div style="text-align: center;">Pts</div>
-            <div style="text-align: center;">Team</div>
-        </div>
-    `;
-    
-    const rowsHtml = topPlayers.map((item, index) => {
-        const rank = index + 1;
-        const bgColor = item.isMyPlayer ? 'rgba(56, 189, 248, 0.1)' : 'var(--bg-primary)';
-        const borderLeft = item.isMyPlayer ? '3px solid var(--primary-color)' : 'none';
-        
-        return `
-            <div class="mobile-table-row mobile-table-dashboard-top" style="background: ${bgColor}; border-left: ${borderLeft};">
-                <div style="text-align: center; font-weight: 600;">${rank}</div>
-                <div>
-                    <div style="font-size: 0.7rem; font-weight: 600; color: var(--text-primary);">
-                        ${escapeHtml(item.player.web_name)}
-                        ${item.isMyPlayer ? ' <span style="color: var(--primary-color);">⭐</span>' : ''}
-                    </div>
-                    <div style="font-size: 0.65rem; color: var(--text-secondary); margin-top: 0.1rem;">
-                        ${item.player.element_type === 1 ? 'GKP' : item.player.element_type === 2 ? 'DEF' : item.player.element_type === 3 ? 'MID' : 'FWD'}
-                    </div>
-                </div>
-                <div style="text-align: center; font-weight: 700; color: var(--text-primary);">
-                    ${item.gwPoints}
-                </div>
-                <div style="text-align: center; font-size: 0.7rem; color: var(--text-secondary);">
-                    ${getTeamShortName(item.player.team)}
-                </div>
-            </div>
-        `;
-    }).join('');
-    
-    return `
+    // Header row (same as stats page: Player, Opp, Status, Pts, Form, GW Pts)
+    let html = `
         <div style="background: var(--bg-secondary); border-radius: 12px; box-shadow: 0 2px 8px var(--shadow); overflow: hidden; margin-top: 1rem;">
             <div style="padding: 0.5rem 0.75rem; background: var(--bg-secondary); border-bottom: 1px solid var(--border-color);">
                 <h4 style="font-size: 0.9rem; font-weight: 700; color: var(--text-primary);">
-                    Top Players (GW${gameweek})
+                    GW Top Performers
                 </h4>
             </div>
-            ${headerRow}
-            ${rowsHtml}
-        </div>
+            <div class="mobile-table">
+                <div class="mobile-table-header" style="grid-template-columns: 2fr 1.2fr 1fr 0.7fr 0.7fr 0.8fr; padding-bottom: 2px !important; padding-top: 2px !important;">
+                    <div>Player</div>
+                    <div style="text-align: center;">Opp</div>
+                    <div style="text-align: center;">Status</div>
+                    <div style="text-align: center;">Pts</div>
+                    <div style="text-align: center;">Form</div>
+                    <div style="text-align: center;">GW Pts</div>
+                </div>
     `;
+    
+    // Render rows (same styling as stats page)
+    topPlayers.forEach((item) => {
+        const player = item.player;
+        const gwOpp = getGWOpponent(player.team, currentGW);
+        const matchStatus = getMatchStatus(player.team, currentGW, player);
+        const isLiveMatch = matchStatus === 'LIVE';
+        const isFinished = matchStatus.startsWith('FT');
+        
+        // GW Points (for Pts column)
+        const gwPoints = isLive ? (player.live_stats?.total_points || 0) : (player.event_points || 0);
+        const ptsHeatmap = getPtsHeatmap(gwPoints, 'gw_pts');
+        const ptsStyle = getHeatmapStyle(ptsHeatmap);
+        
+        // Form
+        const formHeatmap = getFormHeatmap(parseFloat(player.form) || 0);
+        const formStyle = getHeatmapStyle(formHeatmap);
+        
+        // GW Points for last column (same value, but displayed again)
+        const gwPtsHeatmap = getPtsHeatmap(gwPoints, 'gw_pts');
+        const gwPtsStyle = getHeatmapStyle(gwPtsHeatmap);
+        
+        // Status styling (matching stats page logic)
+        let statusColor = 'var(--text-secondary)';
+        let statusWeight = '400';
+        let statusBgColor = 'transparent';
+        
+        if (isFinished && matchStatus.includes('(')) {
+            const minsMatch = matchStatus.match(/\((\d+)\)/);
+            if (minsMatch) {
+                const mins = parseInt(minsMatch[1]);
+                statusWeight = '700';
+                if (mins >= 90) {
+                    statusColor = '#86efac';
+                    statusBgColor = 'rgba(31, 77, 46, 1.0)';
+                } else if (mins >= 60) {
+                    statusColor = '#fcd34d';
+                    statusBgColor = 'rgba(92, 74, 31, 1.0)';
+                } else {
+                    statusColor = '#fca5a5';
+                    statusBgColor = 'rgba(92, 31, 31, 1.0)';
+                }
+            } else {
+                statusColor = '#22c55e';
+            }
+        } else if (isLiveMatch) {
+            statusColor = '#ef4444';
+            statusWeight = '700';
+        }
+        
+        // Colored left border for players with news/injury
+        let leftBorderStyle = 'none';
+        if (item.isMyPlayer) {
+            leftBorderStyle = '3px solid var(--primary-color)';
+        } else if (player.news && player.news.trim() !== '') {
+            const chanceOfPlaying = player.chance_of_playing_next_round;
+            if (chanceOfPlaying !== null && chanceOfPlaying !== undefined) {
+                if (chanceOfPlaying <= 25) {
+                    leftBorderStyle = '3px solid #ef4444';
+                } else if (chanceOfPlaying <= 50) {
+                    leftBorderStyle = '3px solid #f97316';
+                } else {
+                    leftBorderStyle = '3px solid #fbbf24';
+                }
+            } else {
+                leftBorderStyle = '3px solid #fbbf24';
+            }
+        }
+        
+        const bgColor = item.isMyPlayer ? 'rgba(56, 189, 248, 0.1)' : 'var(--bg-primary)';
+        
+        html += `
+            <div
+                class="player-row mobile-table-row"
+                style="grid-template-columns: 2fr 1.2fr 1fr 0.7fr 0.7fr 0.8fr; cursor: pointer; padding-bottom: 3px !important; padding-top: 3px !important; border-left: ${leftBorderStyle}; background: ${bgColor};"
+                data-player-id="${player.id}"
+            >
+                <div style="font-weight: 600; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                    ${escapeHtml(player.web_name)}
+                    ${item.isMyPlayer ? ' <span style="color: var(--primary-color); font-size: 0.75rem;">⭐</span>' : ''}
+                </div>
+                <div style="text-align: center;">
+                    <span class="${getDifficultyClass(gwOpp.difficulty)}" style="padding: 0.08rem 0.25rem; border-radius: 0.25rem; font-weight: 700; font-size: 0.6rem; min-width: 3rem; display: inline-block; text-align: center;">
+                        ${gwOpp.name} (${gwOpp.isHome ? 'H' : 'A'})
+                    </span>
+                </div>
+                <div style="text-align: center; font-size: 0.6rem; font-weight: ${statusWeight}; color: ${statusColor}; background: ${statusBgColor}; padding: 0.08rem 0.25rem; border-radius: 0.25rem;">${matchStatus}</div>
+                <div style="text-align: center; background: ${ptsStyle.background}; color: ${ptsStyle.color}; font-weight: 700; padding: 0.08rem 0.25rem; border-radius: 0.25rem; font-size: 0.6rem;">${gwPoints}</div>
+                <div style="text-align: center; background: ${formStyle.background}; color: ${formStyle.color}; font-weight: 700; padding: 0.08rem 0.25rem; border-radius: 0.25rem; font-size: 0.6rem;">${formatDecimal(player.form)}</div>
+                <div style="text-align: center; background: ${gwPtsStyle.background}; color: ${gwPtsStyle.color}; font-weight: 700; padding: 0.08rem 0.25rem; border-radius: 0.25rem; font-size: 0.6rem;">${gwPoints}</div>
+            </div>
+        `;
+    });
+    
+    html += `</div></div>`;
+    return html;
 }
 


### PR DESCRIPTION
- Update header card to show Total Pts, GW Pts (with placeholder for UPCOMING), Overall Rank, and GW Rank (with placeholder) in right column
- Fix two-column layout to be 75-25 side-by-side (3fr 1fr) instead of stacked
- Update Top Performers table to use exact same styling as stats page with GW Points in last column
- Show placeholder messages when GW is UPCOMING (24h before deadline)