### PR TITLE
Align stats page columns and reduce rival points box

### DIFF
--- a/frontend/src/renderDataAnalysis.js
+++ b/frontend/src/renderDataAnalysis.js
@@ -769,7 +769,7 @@ function renderPositionSpecificTableMobile(players, contextColumn = 'total') {
     // Header row
     let html = `
         <div class="mobile-table">
-            <div class="mobile-table-header" style="display: grid; grid-template-columns: 2fr 1.2fr 1fr 0.7fr 0.7fr 0.8fr; padding-bottom: 2px !important; padding-top: 2px !important;">
+            <div class="mobile-table-header" style="display: grid; grid-template-columns: 2.5fr 1fr 1fr 0.8fr 0.8fr 0.8fr; padding-bottom: 2px !important; padding-top: 2px !important;">
                 <div>Player</div>
                 <div style="text-align: center;">Opp</div>
                 <div style="text-align: center;">Status</div>
@@ -869,7 +869,7 @@ function renderPositionSpecificTableMobile(players, contextColumn = 'total') {
         html += `
             <div
                 class="player-row mobile-table-row"
-                style="display: grid; grid-template-columns: 2fr 1.2fr 1fr 0.7fr 0.7fr 0.8fr; cursor: pointer; padding-bottom: 3px !important; padding-top: 3px !important; border-left: ${leftBorderStyle};"
+                style="display: grid; grid-template-columns: 2.5fr 1fr 1fr 0.8fr 0.8fr 0.8fr; cursor: pointer; padding-bottom: 3px !important; padding-top: 3px !important; border-left: ${leftBorderStyle};"
                 data-player-id="${player.id}"
             >
                 <div style="font-weight: 600; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">

--- a/frontend/src/renderRivalTeam.js
+++ b/frontend/src/renderRivalTeam.js
@@ -265,10 +265,10 @@ function renderRivalCompactHeader(teamData, gwNumber) {
                         border-radius: 6px;
                         padding: 0.3rem 0.6rem;
                         text-align: center;
-                        min-width: 175px;
+                        min-width: 90px;
                         display: flex;
                         flex-direction: column;
-                        justify-content: right;
+                        justify-content: center;
                         box-shadow: 0 1px 3px var(--shadow);
                     ">
                         <div style="font-size: 2rem; font-weight: 800; color: ${gwIndicator.color}; line-height: 1;">


### PR DESCRIPTION
- Stats page: Match Team page grid (2.5fr 1fr 1fr 0.8fr 0.8fr 0.8fr)
- Rival score card: Reduce points box min-width to 90px