### PR TITLE
feat: add transfer history with points comparison

### DIFF
--- a/backend/routes/fplRoutes.js
+++ b/backend/routes/fplRoutes.js
@@ -8,7 +8,8 @@ import {
   fetchBootstrap,
   fetchFixtures,
   fetchElementSummary,
-  fetchLiveGameweekData
+  fetchLiveGameweekData,
+  fetchTransferHistory
 } from '../services/fplService.js';
 import { fetchGithubCSV } from '../services/githubService.js';
 import {
@@ -405,6 +406,45 @@ router.get('/api/player/:playerId/summary', async (req, res) => {
     logger.error(`❌ Error fetching player ${id} summary:`, err.message);
     res.status(500).json({
       error: 'Failed to fetch player summary',
+      message: err.message
+    });
+  }
+});
+
+// ============================================================================
+// TRANSFER HISTORY ENDPOINT
+// ============================================================================
+
+/**
+ * GET /api/team/:teamId/transfers
+ * Returns transfer history for a team
+ */
+router.get('/api/team/:teamId/transfers', async (req, res) => {
+  const { teamId } = req.params;
+
+  logger.log(`📥 GET /api/team/${teamId}/transfers`);
+
+  // Validate team ID
+  const id = parseInt(teamId);
+  if (isNaN(id) || id <= 0) {
+    return res.status(400).json({
+      error: 'Invalid team ID',
+      message: 'Team ID must be a positive integer'
+    });
+  }
+
+  try {
+    const transfers = await fetchTransferHistory(id);
+
+    res.json({
+      transfers: transfers || [],
+      count: transfers?.length || 0,
+      timestamp: new Date().toISOString()
+    });
+  } catch (err) {
+    logger.error(`❌ Error fetching transfers for team ${id}:`, err.message);
+    res.status(500).json({
+      error: 'Failed to fetch transfer history',
       message: err.message
     });
   }

--- a/backend/services/fplService.js
+++ b/backend/services/fplService.js
@@ -249,6 +249,35 @@ export async function fetchElementSummary(playerId) {
 }
 
 // ============================================================================
+// TRANSFER HISTORY
+// ============================================================================
+
+/**
+ * Fetch transfer history for a team
+ * @param {string|number} teamId - FPL team ID
+ * @returns {Promise<Array>} Array of transfers
+ */
+export async function fetchTransferHistory(teamId) {
+  logger.log(`📡 Fetching transfer history for team ${teamId}...`);
+
+  try {
+    const response = await axios.get(`${FPL_BASE_URL}/entry/${teamId}/transfers/`, {
+      timeout: 10000,
+      headers: {
+        'User-Agent': 'FPLanner/1.0'
+      }
+    });
+
+    logger.log(`✅ Transfer history fetched for team ${teamId} (${response.data.length} transfers)`);
+    recordFetch();
+    return response.data;
+  } catch (err) {
+    logger.error(`❌ Failed to fetch transfer history for team ${teamId}:`, err.message);
+    throw new Error(`Transfer history unavailable for team ${teamId}`);
+  }
+}
+
+// ============================================================================
 // LEAGUE DATA
 // ============================================================================
 

--- a/frontend/src/data.js
+++ b/frontend/src/data.js
@@ -512,6 +512,32 @@ export async function loadLeagueStandings(leagueId, page = 1) {
 }
 
 /**
+ * Load transfer history for a team
+ * @param {string|number} teamId - Team ID
+ * @returns {Promise<Array>} Array of transfers
+ */
+export async function loadTransferHistory(teamId) {
+    console.log(`🔄 Loading transfer history for team ${teamId}...`);
+
+    try {
+        const response = await fetch(`${API_BASE}/team/${teamId}/transfers`);
+
+        if (!response.ok) {
+            throw new Error(`Failed to load transfer history for team ${teamId}`);
+        }
+
+        const data = await response.json();
+
+        console.log(`✅ Transfer history loaded (${data.count} transfers)`);
+
+        return data.transfers || [];
+    } catch (err) {
+        console.error(`❌ Failed to load transfer history:`, err);
+        throw err;
+    }
+}
+
+/**
  * Detect current gameweek from bootstrap data
  * Sets the module-level currentGW variable to latest finished gameweek
  * @private

--- a/frontend/src/renderMyTeam.js
+++ b/frontend/src/renderMyTeam.js
@@ -119,6 +119,7 @@ import {
     renderCompactTeamList,
     renderMatchSchedule,
     attachPlayerRowListeners,
+    attachTransferListeners,
     showPlayerModal
 } from './renderMyTeamCompact.js';
 
@@ -482,6 +483,7 @@ export function renderMyTeam(teamData, subTab = 'overview') {
         requestAnimationFrame(() => {
             if (subTab === 'overview') {
                 attachPlayerRowListeners(myTeamState);
+                attachTransferListeners();
             } else if (subTab === 'fixtures') {
                 attachMobileFixtureRowListeners();
             }

--- a/frontend/src/renderMyTeamCompact.js
+++ b/frontend/src/renderMyTeamCompact.js
@@ -4,7 +4,7 @@
 // ============================================================================
 
 // Re-export all functions from compact modules
-export { renderCompactHeader } from './myTeam/compact/compactHeader.js';
+export { renderCompactHeader, attachTransferListeners } from './myTeam/compact/compactHeader.js';
 export { renderCompactPlayerRow } from './myTeam/compact/compactPlayerRow.js';
 export { renderCompactTeamList } from './myTeam/compact/compactTeamList.js';
 export { renderMatchSchedule } from './myTeam/compact/compactSchedule.js';


### PR DESCRIPTION
- Add fetchTransferHistory endpoint to backend (/api/team/:teamId/transfers)
- Add loadTransferHistory function to frontend data module
- Make transfers row in Team header clickable/expandable
- Show player OUT and IN with GW points
- Display net points difference (green=good, red=bad)
- Cache transfer history to avoid repeated API calls