### PR TITLE
feat: redesign Planner risk prioritization system

### DIFF
--- a/frontend/src/risk.js
+++ b/frontend/src/risk.js
@@ -92,7 +92,7 @@ export function analyzePlayerRisks(player) {
         if (minutesPct < 50 && player.minutes > 0) {
             risks.push({
                 type: 'rotation',
-                severity: minutesPct < 30 ? 'high' : 'medium',
+                severity: minutesPct < 30 ? 'medium' : 'low',
                 icon: '🔄',
                 message: `${minutesPct.toFixed(0)}% minutes`,
                 details: `Low playing time - rotation risk (${minutesPct.toFixed(0)}% of available minutes)`
@@ -103,14 +103,14 @@ export function analyzePlayerRisks(player) {
     // 4. POOR FORM
     const form = parseFloat(player.form) || 0;
     const avgPoints = gw > 0 ? (player.total_points || 0) / gw : 0;
-    
+
     if (form < 3 && gw >= 3 && player.minutes > 180) {
         risks.push({
             type: 'form',
-            severity: form < 2 ? 'high' : 'medium',
+            severity: 'low',
             icon: '📉',
             message: `Form: ${form.toFixed(1)}`,
-            details: `Poor recent form (${form.toFixed(1)} pts/game)`
+            details: `Poor recent form (${form.toFixed(1)})`
         });
     }
     


### PR DESCRIPTION
Risk severity changes:
- Severe rotation (< 30%) moved to MEDIUM (was HIGH)
- Mild rotation (30-50%) moved to LOW (was MEDIUM)
- Poor form moved to LOW (was HIGH/MEDIUM)
- All yellow card warnings (4+) now MEDIUM

Planner improvements:
- Show ALL risks (HIGH, MEDIUM, LOW) instead of filtering
- Header shows severity breakdown: 🔴 1 • 🟠 2 • 🟡 4
- 4px colored left borders (red/orange/yellow) instead of 3px
- Removed orange background tint for cleaner look
- Chevron moved next to player name (no horizontal scrolling needed)
- Chevron only for HIGH and MEDIUM (actionable risks)
- Consistent 4px borders matching Team/Stats pages

Risk colors:
- 🔴 RED (4px): Injury <50%, Red card, Deadwood
- 🟠 ORANGE (4px): Injury 50-75%, 4+ yellows, Severe rotation <30%
- 🟡 YELLOW (4px): Mild rotation, Poor form, Poor value, Price drop