### PR TITLE
fix: correct Opp column and next 5 GW fixtures to use activeGW

### DIFF
--- a/frontend/src/fixtures.js
+++ b/frontend/src/fixtures.js
@@ -3,7 +3,7 @@
 // Handles fixture analysis, opponent lookups, and difficulty calculations
 // ============================================================================
 
-import { fplFixtures, fplBootstrap, currentGW } from './data.js';
+import { fplFixtures, fplBootstrap, currentGW, getActiveGW } from './data.js';
 import { getTeamByCode } from './utils.js';
 import { memoizeWithDependency } from './utils/memoize.js';
 
@@ -62,10 +62,12 @@ export function getFixtures(teamId, count = 3, isPast = false) {
         teamFixtures.sort((a, b) => a.event - b.event);
         
         // Get past or future fixtures
-        // CRITICAL: Use > (not >=) to exclude current gameweek for future fixtures
-        const relevantFixtures = isPast ? 
+        // CRITICAL: Use > (not >=) to exclude current/active gameweek for future fixtures
+        // For future: use activeGW to exclude current live/upcoming GW
+        // For past: use currentGW for historical data
+        const relevantFixtures = isPast ?
             teamFixtures.filter(f => f.event < currentGW).slice(-count) :
-            teamFixtures.filter(f => f.event > currentGW).slice(0, count);
+            teamFixtures.filter(f => f.event > getActiveGW()).slice(0, count);
         
         relevantFixtures.forEach(f => {
             const isHome = f.team_h === teamId;


### PR DESCRIPTION
Issue: Opp column showing N/A and next 5 GW columns including current GW

Changes to compactTeamList.js:
- Import getActiveGW from data.js
- Calculate activeGW at function level
- Pass activeGW to renderTeamSection
- Use activeGW for Opp column (shows current/live GW opponent)
- Use activeGW for next5GWs calculation (excludes current GW)

Changes to fixtures.js:
- Import getActiveGW from data.js
- Update getFixtures to use activeGW for future fixtures
- Use activeGW() instead of currentGW for filtering future fixtures
- This ensures next 5 fixtures exclude the current/active GW

Example:
- If activeGW = 13 (current/live GW)
- Opp column: shows GW 13 opponent
- Next 5 columns: shows GW 14, 15, 16, 17, 18 (NOT including GW 13)

This fix applies to both Team and Planner pages since both use getFixtures().