### PR TITLE
feat: improve heatmap consistency and add transfer delta pill

### DIFF
--- a/frontend/src/myTeam/compact/compactStyleHelpers.js
+++ b/frontend/src/myTeam/compact/compactStyleHelpers.js
@@ -132,6 +132,7 @@ export function calculateStatusColor(matchStatus) {
     const isLive = matchStatus.startsWith('LIVE');
     const isFinished = matchStatus.startsWith('FT');
 
+    // Use same heat-* variables as Form/Pts columns for consistency
     let statusColor = 'var(--text-secondary)';
     let statusBgColor = 'transparent';
     let statusWeight = '400';
@@ -143,17 +144,19 @@ export function calculateStatusColor(matchStatus) {
             const mins = parseInt(minsMatch[1]);
             statusWeight = '700';
             if (mins >= 90) {
-                statusColor = '#86efac'; // Soft green
-                statusBgColor = 'rgba(31, 77, 46, 1.0)';
+                statusColor = 'var(--heat-dark-green-text)';
+                statusBgColor = 'var(--heat-dark-green-bg)';
             } else if (mins >= 60) {
-                statusColor = '#fcd34d'; // Soft yellow/orange
-                statusBgColor = 'rgba(92, 74, 31, 1.0)';
+                statusColor = 'var(--heat-yellow-text)';
+                statusBgColor = 'var(--heat-yellow-bg)';
             } else {
-                statusColor = '#fca5a5'; // Soft red
-                statusBgColor = 'rgba(92, 31, 31, 1.0)';
+                statusColor = 'var(--heat-red-text)';
+                statusBgColor = 'var(--heat-red-bg)';
             }
         } else {
-            statusColor = '#22c55e'; // FT but no minutes data
+            statusColor = 'var(--heat-light-green-text)';
+            statusBgColor = 'var(--heat-light-green-bg)';
+            statusWeight = '700';
         }
     } else if (isLive) {
         statusColor = '#ef4444';

--- a/frontend/src/myTeam/compact/compactTeamList.js
+++ b/frontend/src/myTeam/compact/compactTeamList.js
@@ -50,12 +50,12 @@ export function renderCompactTeamList(players, gwNumber, isLive) {
                             <th style="text-align: center; padding: 0.5rem; min-width: 50px;">Status</th>
                             <th style="text-align: center; padding: 0.5rem; min-width: 35px;">Pts</th>
                             <th style="text-align: center; padding: 0.5rem; min-width: 40px;">Form</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 50px;">Δ</th>
                             <th style="text-align: center; padding: 0.5rem; min-width: 45px;">Price</th>
                             <th style="text-align: center; padding: 0.5rem; min-width: 55px;">Defcon</th>
                             <th style="text-align: center; padding: 0.5rem; min-width: 50px;">xGI/xGC</th>
                             <th style="text-align: center; padding: 0.5rem; min-width: 40px;">PPM</th>
                             <th style="text-align: center; padding: 0.5rem; min-width: 45px;">Own%</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 50px;">Δ</th>
                             ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 50px;">GW${gw}</th>`).join('')}
                         </tr>
                     </thead>
@@ -179,6 +179,11 @@ function renderTeamSection(players, gwNumber, isLive, next5GWs, activeGW, sectio
                     ${formatDecimal(player.form)}
                 </td>
                 <td style="text-align: center; padding: 0.5rem;">
+                    <span style="display: inline-block; padding: 0.2rem 0.4rem; border-radius: 3px; font-weight: 600; font-size: 0.65rem; background: ${transferDelta > 0 ? 'rgba(34, 197, 94, 0.2)' : transferDelta < 0 ? 'rgba(239, 68, 68, 0.2)' : 'transparent'}; color: ${transferColor};">
+                        ${transferDelta > 0 ? '+' : ''}${(transferDelta / 1000).toFixed(0)}k
+                    </span>
+                </td>
+                <td style="text-align: center; padding: 0.5rem;">
                     ${formatCurrency(player.now_cost)}
                 </td>
                 <td style="text-align: center; padding: 0.5rem; font-weight: 600;">
@@ -192,9 +197,6 @@ function renderTeamSection(players, gwNumber, isLive, next5GWs, activeGW, sectio
                 </td>
                 <td style="text-align: center; padding: 0.5rem; font-size: 0.65rem;">
                     ${ownership.toFixed(1)}%
-                </td>
-                <td style="text-align: center; padding: 0.5rem; color: ${transferColor}; font-weight: 600; font-size: 0.65rem;">
-                    ${transferDelta > 0 ? '+' : ''}${(transferDelta / 1000).toFixed(0)}k
                 </td>
                 ${next5Fixtures.map(fix => {
                     const fdrClass = getDifficultyClass(fix.difficulty);

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -162,8 +162,8 @@ export function getPtsHeatmap(points, metric = 'pts') {
         if (points >= 10) return 'heat-dark-green';
         if (points >= 7) return 'heat-light-green';
         if (points >= 4) return 'heat-yellow';
-        if (points >= 1) return 'heat-red';
-        return 'heat-gray';
+        if (points >= 0) return 'heat-red'; // Include 0 pts as red (poor)
+        return 'heat-gray'; // Only for negative/invalid values
     }
 
     if (metric === 'form') {


### PR DESCRIPTION
1. Fix 0 pts heatmap handling (utils.js):
   - Changed from >= 1 to >= 0 for red category
   - 0 pts now shows as red (poor) instead of gray (no data)
   - Gray reserved only for null/undefined/negative values

2. Align Status column shading (compactStyleHelpers.js):
   - Changed from custom colors to heat-* CSS variables
   - Now matches Form/Pts heatmap shading for consistency
   - 90+ mins: dark green, 60-89 mins: yellow, <60 mins: red
   - Uses var(--heat-dark-green-bg/text) etc.

3. Swap Δ and Price column positions (compactTeamList.js):
   - New order: ..., Form, Δ, Price, Defcon, xGI/xGC, PPM, Own%, ...
   - Transfer momentum now appears before Price column

4. Add pill styling for Transfer Δ (compactTeamList.js):
   - Subtle green background for positive (rgba(34, 197, 94, 0.2))
   - Subtle red background for negative (rgba(239, 68, 68, 0.2))
   - Transparent for zero delta
   - Matches "change indicator" visual category

Visual hierarchy now clear:
- Fixture pills (Opp, GW columns) = Categorical data
- Performance heatmaps (Pts, Form) = Continuous metrics
- Change indicators (Δ) = Delta with subtle pill