### PR TITLE
refactor: standardize mobile table column widths with bottom-up sizing

### DIFF
--- a/frontend/src/myTeam/compact/compactTeamList.js
+++ b/frontend/src/myTeam/compact/compactTeamList.js
@@ -42,21 +42,21 @@ export function renderCompactTeamList(players, gwNumber, isLive) {
             margin-bottom: 0.5rem;
         ">
             <div style="overflow-x: auto; -webkit-overflow-scrolling: touch;">
-                <table style="width: 100%; font-size: 0.7rem; border-collapse: collapse; min-width: 1000px;">
+                <table style="width: 100%; font-size: 0.7rem; border-collapse: collapse;">
                     <thead style="background: var(--bg-tertiary);">
                         <tr>
-                            <th style="position: sticky; left: 0; background: var(--bg-tertiary); z-index: 10; text-align: left; padding: 0.5rem; min-width: 100px;">Player</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 45px;">Opp</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 50px;">Status</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 35px;">Pts</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 40px;">Form</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 50px;">Δ</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 45px;">Price</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 55px;">Defcon</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 50px;">xGI/xGC</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 40px;">PPM</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 45px;">Own%</th>
-                            ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 50px;">GW${gw}</th>`).join('')}
+                            <th style="position: sticky; left: 0; background: var(--bg-tertiary); z-index: 10; text-align: left; padding: 0.5rem; min-width: 140px;">Player</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Opp</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Status</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Pts</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Form</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Δ</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Price</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Defcon</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">xGI/xGC</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">PPM</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Own%</th>
+                            ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 120px;">GW${gw}</th>`).join('')}
                         </tr>
                     </thead>
                     <tbody>

--- a/frontend/src/renderDataAnalysis.js
+++ b/frontend/src/renderDataAnalysis.js
@@ -829,15 +829,15 @@ function renderPositionSpecificTableMobile(players, contextColumn = 'total') {
             margin-bottom: 0.5rem;
         ">
             <div style="overflow-x: auto; -webkit-overflow-scrolling: touch;">
-                <table style="width: 100%; font-size: 0.7rem; border-collapse: collapse; min-width: 800px;">
+                <table style="width: 100%; font-size: 0.7rem; border-collapse: collapse;">
                     <thead style="background: var(--bg-tertiary);">
                         <tr>
-                            <th style="position: sticky; left: 0; background: var(--bg-tertiary); z-index: 10; text-align: left; padding: 0.5rem; min-width: 100px;">Player</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 45px;">Opp</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 50px;">Status</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 35px;">Pts</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 40px;">Form</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 50px;">${config.header}</th>
+                            <th style="position: sticky; left: 0; background: var(--bg-tertiary); z-index: 10; text-align: left; padding: 0.5rem; min-width: 140px;">Player</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Opp</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Status</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Pts</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Form</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">${config.header}</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/frontend/src/renderPlanner.js
+++ b/frontend/src/renderPlanner.js
@@ -185,13 +185,13 @@ function renderUnifiedFixtureTable(myPlayers, riskPlayerMap, picks, gwNumber) {
             overflow: hidden;
         ">
             <div style="overflow-x: auto; -webkit-overflow-scrolling: touch;">
-                <table style="width: 100%; font-size: 0.75rem; border-collapse: collapse; min-width: 550px;">
+                <table style="width: 100%; font-size: 0.75rem; border-collapse: collapse;">
                     <thead style="background: var(--bg-tertiary);">
                         <tr>
-                            <th style="position: sticky; left: 0; background: var(--bg-tertiary); z-index: 10; text-align: left; padding: 0.5rem; min-width: 110px;">Player</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 40px;">FDR</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 45px;">Form</th>
-                            ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 50px;">GW${gw}</th>`).join('')}
+                            <th style="position: sticky; left: 0; background: var(--bg-tertiary); z-index: 10; text-align: left; padding: 0.5rem; min-width: 140px;">Player</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">FDR</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Form</th>
+                            ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 120px;">GW${gw}</th>`).join('')}
                         </tr>
                     </thead>
                     <tbody>
@@ -355,13 +355,13 @@ function renderProblemPlayersSection_OLD(myPlayers, picks, gwNumber) {
 function renderProblemPlayersTable(problemPlayers, picks, next5GWs, gwNumber) {
     let html = `
         <div style="overflow-x: auto; -webkit-overflow-scrolling: touch;">
-            <table style="width: 100%; font-size: 0.75rem; border-collapse: collapse; min-width: 600px;">
+            <table style="width: 100%; font-size: 0.75rem; border-collapse: collapse;">
                 <thead style="background: var(--bg-tertiary);">
                     <tr>
-                        <th style="position: sticky; left: 0; background: var(--bg-tertiary); z-index: 10; text-align: left; padding: 0.5rem; min-width: 120px;">Player</th>
-                        <th style="text-align: center; padding: 0.5rem; min-width: 50px;">Issue</th>
-                        <th style="text-align: center; padding: 0.5rem; min-width: 45px;">Form</th>
-                        ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 50px;">GW${gw}</th>`).join('')}
+                        <th style="position: sticky; left: 0; background: var(--bg-tertiary); z-index: 10; text-align: left; padding: 0.5rem; min-width: 140px;">Player</th>
+                        <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Issue</th>
+                        <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Form</th>
+                        ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 120px;">GW${gw}</th>`).join('')}
                     </tr>
                 </thead>
                 <tbody>
@@ -475,12 +475,12 @@ function renderFixtureTicker(myPlayers, gwNumber) {
             </div>
             <div id="planner-ticker-content" style="display: none;">
                 <div style="overflow-x: auto; -webkit-overflow-scrolling: touch;">
-                    <table style="width: 100%; font-size: 0.75rem; border-collapse: collapse; min-width: 500px;">
+                    <table style="width: 100%; font-size: 0.75rem; border-collapse: collapse;">
                         <thead style="background: var(--bg-tertiary);">
                             <tr>
-                                <th style="position: sticky; left: 0; background: var(--bg-tertiary); z-index: 10; text-align: left; padding: 0.5rem; min-width: 100px;">Player</th>
-                                <th style="text-align: center; padding: 0.5rem; min-width: 40px;">FDR</th>
-                                ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 50px;">GW${gw}</th>`).join('')}
+                                <th style="position: sticky; left: 0; background: var(--bg-tertiary); z-index: 10; text-align: left; padding: 0.5rem; min-width: 140px;">Player</th>
+                                <th style="text-align: center; padding: 0.5rem; min-width: 120px;">FDR</th>
+                                ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 120px;">GW${gw}</th>`).join('')}
                             </tr>
                         </thead>
                         <tbody>
@@ -616,13 +616,13 @@ function renderTransferTargets(myPlayers, picks, gwNumber) {
             </div>
             <div id="planner-targets-content" style="display: none;">
                 <div style="overflow-x: auto; -webkit-overflow-scrolling: touch;">
-                    <table style="width: 100%; font-size: 0.75rem; border-collapse: collapse; min-width: 550px;">
+                    <table style="width: 100%; font-size: 0.75rem; border-collapse: collapse;">
                         <thead style="background: var(--bg-tertiary);">
                             <tr>
-                                <th style="position: sticky; left: 0; background: var(--bg-tertiary); z-index: 10; text-align: left; padding: 0.5rem; min-width: 120px;">Player</th>
-                                <th style="text-align: center; padding: 0.5rem; min-width: 45px;">Form</th>
-                                <th style="text-align: center; padding: 0.5rem; min-width: 40px;">FDR</th>
-                                ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 50px;">GW${gw}</th>`).join('')}
+                                <th style="position: sticky; left: 0; background: var(--bg-tertiary); z-index: 10; text-align: left; padding: 0.5rem; min-width: 140px;">Player</th>
+                                <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Form</th>
+                                <th style="text-align: center; padding: 0.5rem; min-width: 120px;">FDR</th>
+                                ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 120px;">GW${gw}</th>`).join('')}
                             </tr>
                         </thead>
                         <tbody>


### PR DESCRIPTION
Switch from top-down sizing (hardcoded table min-widths) to bottom-up sizing (standardized cell min-widths) across Team, Planner, and Stats pages.

Changes:
- Remove hardcoded min-width from all <table> elements
- Standardize column min-widths to 120px for better consistency
- Set first column (sticky) to 140px for adequate player name space
- Tables now grow naturally based on cell content instead of fixed widths

This makes the layout more maintainable - adding/removing columns no longer requires manually adjusting table widths.

Files modified:
- frontend/src/myTeam/compact/compactTeamList.js (Team page)
- frontend/src/renderPlanner.js (Planner page - 4 tables)
- frontend/src/renderDataAnalysis.js (Stats page)