### PR TITLE
refactor: reduce standard column widths from 120px to 60px

### DIFF
--- a/frontend/src/myTeam/compact/compactTeamList.js
+++ b/frontend/src/myTeam/compact/compactTeamList.js
@@ -46,17 +46,17 @@ export function renderCompactTeamList(players, gwNumber, isLive) {
                     <thead style="background: var(--bg-tertiary);">
                         <tr>
                             <th style="position: sticky; left: 0; background: var(--bg-tertiary); z-index: 10; text-align: left; padding: 0.5rem; min-width: 140px;">Player</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Opp</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Status</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Pts</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Form</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Δ</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Price</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Defcon</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">xGI/xGC</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">PPM</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Own%</th>
-                            ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 120px;">GW${gw}</th>`).join('')}
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Opp</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Status</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Pts</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Form</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Δ</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Price</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Defcon</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">xGI/xGC</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">PPM</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Own%</th>
+                            ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 60px;">GW${gw}</th>`).join('')}
                         </tr>
                     </thead>
                     <tbody>

--- a/frontend/src/renderDataAnalysis.js
+++ b/frontend/src/renderDataAnalysis.js
@@ -833,11 +833,11 @@ function renderPositionSpecificTableMobile(players, contextColumn = 'total') {
                     <thead style="background: var(--bg-tertiary);">
                         <tr>
                             <th style="position: sticky; left: 0; background: var(--bg-tertiary); z-index: 10; text-align: left; padding: 0.5rem; min-width: 140px;">Player</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Opp</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Status</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Pts</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Form</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">${config.header}</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Opp</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Status</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Pts</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Form</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">${config.header}</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/frontend/src/renderPlanner.js
+++ b/frontend/src/renderPlanner.js
@@ -189,9 +189,9 @@ function renderUnifiedFixtureTable(myPlayers, riskPlayerMap, picks, gwNumber) {
                     <thead style="background: var(--bg-tertiary);">
                         <tr>
                             <th style="position: sticky; left: 0; background: var(--bg-tertiary); z-index: 10; text-align: left; padding: 0.5rem; min-width: 140px;">Player</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">FDR</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Form</th>
-                            ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 120px;">GW${gw}</th>`).join('')}
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">FDR</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Form</th>
+                            ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 60px;">GW${gw}</th>`).join('')}
                         </tr>
                     </thead>
                     <tbody>
@@ -359,9 +359,9 @@ function renderProblemPlayersTable(problemPlayers, picks, next5GWs, gwNumber) {
                 <thead style="background: var(--bg-tertiary);">
                     <tr>
                         <th style="position: sticky; left: 0; background: var(--bg-tertiary); z-index: 10; text-align: left; padding: 0.5rem; min-width: 140px;">Player</th>
-                        <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Issue</th>
-                        <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Form</th>
-                        ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 120px;">GW${gw}</th>`).join('')}
+                        <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Issue</th>
+                        <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Form</th>
+                        ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 60px;">GW${gw}</th>`).join('')}
                     </tr>
                 </thead>
                 <tbody>
@@ -479,8 +479,8 @@ function renderFixtureTicker(myPlayers, gwNumber) {
                         <thead style="background: var(--bg-tertiary);">
                             <tr>
                                 <th style="position: sticky; left: 0; background: var(--bg-tertiary); z-index: 10; text-align: left; padding: 0.5rem; min-width: 140px;">Player</th>
-                                <th style="text-align: center; padding: 0.5rem; min-width: 120px;">FDR</th>
-                                ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 120px;">GW${gw}</th>`).join('')}
+                                <th style="text-align: center; padding: 0.5rem; min-width: 60px;">FDR</th>
+                                ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 60px;">GW${gw}</th>`).join('')}
                             </tr>
                         </thead>
                         <tbody>
@@ -620,9 +620,9 @@ function renderTransferTargets(myPlayers, picks, gwNumber) {
                         <thead style="background: var(--bg-tertiary);">
                             <tr>
                                 <th style="position: sticky; left: 0; background: var(--bg-tertiary); z-index: 10; text-align: left; padding: 0.5rem; min-width: 140px;">Player</th>
-                                <th style="text-align: center; padding: 0.5rem; min-width: 120px;">Form</th>
-                                <th style="text-align: center; padding: 0.5rem; min-width: 120px;">FDR</th>
-                                ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 120px;">GW${gw}</th>`).join('')}
+                                <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Form</th>
+                                <th style="text-align: center; padding: 0.5rem; min-width: 60px;">FDR</th>
+                                ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 60px;">GW${gw}</th>`).join('')}
                             </tr>
                         </thead>
                         <tbody>


### PR DESCRIPTION
Optimize mobile table spacing by reducing standard column min-widths from 120px to 60px across all three pages. First column (Player) remains at 140px for adequate name space.

This creates more compact tables that fit better on mobile screens while maintaining readability.

Files modified:
- frontend/src/myTeam/compact/compactTeamList.js (Team page)
- frontend/src/renderPlanner.js (Planner page - 4 tables)
- frontend/src/renderDataAnalysis.js (Stats page)