### PR TITLE
feat: Add interactive mobile planner with sandbox team editing

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -123,7 +123,12 @@ function renderPage() {
             renderSearch();
             break;
         case 'planner':
-            renderPlannerPage();
+            // Check if it's a replacement page
+            if (currentSubTab === 'replace' && position) {
+                renderPlayerReplacementPage(parseInt(position));
+            } else {
+                renderPlannerPage();
+            }
             break;
         default:
             container.innerHTML = '<p>Page not found</p>';
@@ -167,6 +172,16 @@ async function renderSearch() {
 async function renderPlannerPage() {
     const { renderPlanner } = await import('./renderPlanner.js');
     renderPlanner();
+}
+
+async function renderPlayerReplacementPage(playerId) {
+    const { renderPlayerReplacementPage } = await import('./planner/replacementPage.js');
+    const container = document.getElementById('app-container');
+    container.innerHTML = renderPlayerReplacementPage(playerId);
+    
+    // Attach event listeners
+    const { attachReplacementPageListeners } = await import('./planner/eventHandlers.js');
+    attachReplacementPageListeners();
 }
 
 // ============================================================================
@@ -337,6 +352,12 @@ async function initializeApp() {
                 // Handle rival/{teamId} route
                 currentRivalId = parseInt(subTab);
                 navigate('rival');
+            } else if (page === 'planner' && subTab === 'replace' && position) {
+                // Handle planner/replace/{playerId} route
+                currentPage = page;
+                currentSubTab = subTab;
+                updateNavLinks();
+                renderPlayerReplacementPage(parseInt(position));
             } else if (page === 'data-analysis' && position) {
                 currentPage = page;
                 currentSubTab = subTab || 'overview';
@@ -602,7 +623,9 @@ window.addEventListener('hashchange', () => {
         currentPage = page;
         currentSubTab = subTab || 'overview';
         updateNavLinks();
-        if (page === 'data-analysis' && position) {
+        if (page === 'planner' && subTab === 'replace' && position) {
+            renderPlayerReplacementPage(parseInt(position));
+        } else if (page === 'data-analysis' && position) {
             renderDataAnalysis(subTab || 'overview', position);
         } else {
             renderPage();

--- a/frontend/src/planner/aiInsights.js
+++ b/frontend/src/planner/aiInsights.js
@@ -1,0 +1,119 @@
+/**
+ * AI Insights for Planner
+ * Loads AI insights based on initial team snapshot (not changes)
+ */
+
+import { loadAndRenderInsights } from '../renderInsightBanner.js';
+import { plannerState } from './state.js';
+import { currentGW } from '../data.js';
+import { getAllPlayers } from '../data.js';
+import { calculateSquadAverages } from '../myTeam/teamSummaryHelpers.js';
+import { analyzePlayerRisks, hasHighRisk, hasMediumRisk } from '../risk.js';
+import { getTeamsWithBestFixtures, getTeamsWithWorstFixtures } from '../fixtures.js';
+import { calculatePPM } from '../utils.js';
+
+/**
+ * Load AI insights for planner
+ * Uses initial team snapshot only (not changes)
+ */
+export async function loadPlannerAIInsights() {
+    const initialSquad = plannerState.getInitialSquad();
+    const initialPicks = plannerState.getInitialPicks();
+    
+    if (!initialSquad || !initialPicks) {
+        console.warn('Cannot load AI insights: no initial squad data');
+        return;
+    }
+
+    const allPlayers = getAllPlayers();
+    const players = initialPicks
+        .map(pick => allPlayers.find(p => p.id === pick.element))
+        .filter(p => p !== undefined);
+
+    if (players.length === 0) {
+        return;
+    }
+
+    // Calculate team metrics
+    const squadAverages = calculateSquadAverages(initialPicks, currentGW);
+
+    // Find problem players
+    const problemPlayers = [];
+    players.forEach(player => {
+        const risks = analyzePlayerRisks(player);
+        if (hasHighRisk(risks) || hasMediumRisk(risks)) {
+            problemPlayers.push({
+                name: player.web_name,
+                position: player.element_type,
+                risks: risks.map(r => r.type),
+                severity: hasHighRisk(risks) ? 'high' : 'medium'
+            });
+        }
+    });
+
+    // Count risks
+    let highRiskCount = 0;
+    let mediumRiskCount = 0;
+    let lowRiskCount = 0;
+
+    players.forEach(player => {
+        const risks = analyzePlayerRisks(player);
+        if (hasHighRisk(risks)) {
+            highRiskCount++;
+        } else if (hasMediumRisk(risks)) {
+            mediumRiskCount++;
+        } else if (risks.length > 0) {
+            lowRiskCount++;
+        }
+    });
+
+    // Get team fixture analysis
+    const teamsWithBestFixtures = getTeamsWithBestFixtures(10, 5);
+    const teamsWithWorstFixtures = getTeamsWithWorstFixtures(10, 5);
+
+    // Prepare context data for AI
+    const contextData = {
+        currentSquad: players.map(p => ({
+            name: p.web_name,
+            position: p.element_type,
+            points: p.total_points,
+            form: parseFloat(p.form) || 0,
+            ppm: calculatePPM(p),
+            ownership: parseFloat(p.selected_by_percent) || 0,
+            price: p.now_cost / 10
+        })),
+        teamMetrics: {
+            avgPPM: squadAverages.avgPPM,
+            avgFDR: squadAverages.avgFDR,
+            avgOwnership: squadAverages.avgOwnership,
+            avgMinPercent: squadAverages.avgMinPercent
+        },
+        problemPlayers,
+        riskCount: {
+            high: highRiskCount,
+            medium: mediumRiskCount,
+            low: lowRiskCount
+        },
+        teamAnalysis: {
+            bestFixtures: teamsWithBestFixtures,
+            worstFixtures: teamsWithWorstFixtures,
+            currentGW
+        }
+    };
+
+    // Build context for AI service
+    const context = {
+        page: 'planner',
+        tab: 'sandbox',
+        position: 'all',
+        gameweek: currentGW,
+        data: contextData
+    };
+
+    // Check if mobile
+    const isMobile = window.innerWidth <= 767;
+
+    // Load and render insights
+    await loadAndRenderInsights(context, 'planner-ai-insights', isMobile);
+}
+

--- a/frontend/src/planner/costCalculator.js
+++ b/frontend/src/planner/costCalculator.js
@@ -1,0 +1,143 @@
+/**
+ * Transfer Cost Calculator
+ * Calculates transfer costs and points hits
+ */
+
+import { getAllPlayers } from '../data.js';
+import { formatCurrency } from '../utils.js';
+import { plannerState } from './state.js';
+
+const POINTS_HIT_PER_TRANSFER = -4;
+
+/**
+ * Calculate transfer costs for changes
+ * @param {Array} changes - Array of {out: playerId, in: playerId}
+ * @param {number} initialBank - Initial bank balance
+ * @returns {Object} Cost summary
+ */
+export function calculateTransferCosts(changes, initialBank) {
+    if (!changes || changes.length === 0) {
+        return {
+            transferCount: 0,
+            freeTransfersUsed: 0,
+            freeTransfersRemaining: 1,
+            pointsHit: 0,
+            budgetImpact: 0,
+            newBank: initialBank
+        };
+    }
+
+    const transferCount = changes.length;
+    
+    // Simple logic: first transfer is free, rest cost -4 points each
+    // In reality, this would track free transfers across gameweeks
+    const freeTransfersUsed = Math.min(1, transferCount);
+    const extraTransfers = Math.max(0, transferCount - freeTransfersUsed);
+    const pointsHit = extraTransfers * POINTS_HIT_PER_TRANSFER;
+
+    // Calculate budget impact
+    const allPlayers = getAllPlayers();
+    let totalCost = 0;
+    
+    changes.forEach(change => {
+        const playerOut = allPlayers.find(p => p.id === change.out);
+        const playerIn = allPlayers.find(p => p.id === change.in);
+        
+        if (playerOut && playerIn) {
+            // Selling price is what you paid (we'll use current price as approximation)
+            // Buying price is current price
+            totalCost += (playerIn.now_cost - playerOut.now_cost);
+        }
+    });
+
+    const newBank = initialBank - totalCost;
+
+    return {
+        transferCount,
+        freeTransfersUsed,
+        freeTransfersRemaining: Math.max(0, 1 - freeTransfersUsed),
+        pointsHit,
+        budgetImpact: -totalCost,
+        newBank
+    };
+}
+
+/**
+ * Render cost summary bar
+ * @param {Object} costSummary - Cost summary object
+ * @returns {string} HTML string
+ */
+export function renderCostSummary(costSummary) {
+    if (!costSummary) {
+        return '';
+    }
+
+    const { transferCount, freeTransfersUsed, freeTransfersRemaining, pointsHit, budgetImpact, newBank } = costSummary;
+
+    const pointsHitColor = pointsHit < 0 ? '#ef4444' : 'var(--text-primary)';
+    const budgetColor = budgetImpact < 0 ? '#ef4444' : budgetImpact > 0 ? '#22c55e' : 'var(--text-primary)';
+
+    return `
+        <div style="
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background: var(--bg-secondary);
+            border-radius: 8px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+            align-items: center;
+            justify-content: space-between;
+        ">
+            <div style="
+                display: flex;
+                flex-wrap: wrap;
+                gap: 1rem;
+                font-size: 0.75rem;
+                color: var(--text-secondary);
+            ">
+                <span>
+                    <strong style="color: var(--text-primary);">Transfers:</strong> 
+                    ${transferCount} (${freeTransfersUsed} free, ${freeTransfersRemaining} remaining)
+                </span>
+                <span style="color: ${pointsHitColor};">
+                    <strong>Points Hit:</strong> ${pointsHit}
+                </span>
+                <span style="color: ${budgetColor};">
+                    <strong>Budget:</strong> ${formatCurrency(newBank)} 
+                    ${budgetImpact !== 0 ? `(${budgetImpact >= 0 ? '+' : ''}${formatCurrency(budgetImpact)})` : ''}
+                </span>
+            </div>
+            <div style="display: flex; gap: 0.5rem;">
+                ${transferCount > 0 ? `
+                    <button
+                        id="planner-reset-all-btn"
+                        style="
+                            padding: 0.4rem 0.75rem;
+                            background: var(--bg-primary);
+                            color: var(--text-primary);
+                            border: 1px solid var(--border-color);
+                            border-radius: 6px;
+                            cursor: pointer;
+                            font-size: 0.7rem;
+                            font-weight: 600;
+                        "
+                    >
+                        Reset All
+                    </button>
+                ` : ''}
+            </div>
+        </div>
+    `;
+}
+
+/**
+ * Get current cost summary
+ * @returns {Object} Cost summary
+ */
+export function getCurrentCostSummary() {
+    const changes = plannerState.getChanges();
+    const initialBank = plannerState.getInitialBank();
+    return calculateTransferCosts(changes, initialBank);
+}
+

--- a/frontend/src/planner/eventHandlers.js
+++ b/frontend/src/planner/eventHandlers.js
@@ -1,0 +1,114 @@
+/**
+ * Planner Event Handlers
+ * Centralized event handlers for planner interactions
+ */
+
+import { plannerState } from './state.js';
+import { renderPlanner } from '../renderPlanner.js';
+
+/**
+ * Handle player click - navigate to replacement page
+ * @param {number} playerId - Player ID clicked
+ */
+export function handlePlayerClick(playerId) {
+    // Navigate to replacement page
+    window.location.hash = `#planner/replace/${playerId}`;
+}
+
+/**
+ * Handle replacement selection - apply swap
+ * @param {number} playerOutId - Player being removed
+ * @param {number} playerInId - Player being added
+ */
+export function handleReplacementSelect(playerOutId, playerInId) {
+    // Add change to state
+    plannerState.addChange(playerOutId, playerInId);
+    
+    // Navigate back to planner
+    window.location.hash = '#planner';
+    
+    // Re-render planner to show changes
+    setTimeout(() => {
+        renderPlanner();
+    }, 100);
+}
+
+/**
+ * Handle individual player reset
+ * @param {number} playerId - Player ID to reset
+ */
+export function handlePlayerReset(playerId) {
+    plannerState.removeChange(playerId);
+    renderPlanner();
+}
+
+/**
+ * Handle global reset - clear all changes
+ */
+export function handleGlobalReset() {
+    plannerState.resetAll();
+    renderPlanner();
+}
+
+/**
+ * Attach event listeners for replacement page
+ */
+export function attachReplacementPageListeners() {
+    // Back button
+    const backBtn = document.getElementById('replacement-back-btn');
+    if (backBtn) {
+        backBtn.addEventListener('click', () => {
+            window.location.hash = '#planner';
+        });
+    }
+
+    // Replacement player rows
+    const replacementRows = document.querySelectorAll('.replacement-player-row');
+    replacementRows.forEach(row => {
+        row.addEventListener('click', () => {
+            const playerInId = parseInt(row.dataset.playerId);
+            const playerOutId = parseInt(row.dataset.originalId);
+            handleReplacementSelect(playerOutId, playerInId);
+        });
+    });
+}
+
+/**
+ * Attach event listeners for planner page
+ */
+export function attachPlannerListeners() {
+    // Player row clicks (navigate to replacement page)
+    const playerRows = document.querySelectorAll('[data-player-id]');
+    playerRows.forEach(row => {
+        const playerId = parseInt(row.dataset.playerId);
+        if (playerId && !row.querySelector('.expand-replacements-btn')) {
+            row.style.cursor = 'pointer';
+            row.addEventListener('click', (e) => {
+                // Don't trigger if clicking on reset button
+                if (e.target.closest('.player-reset-btn')) {
+                    return;
+                }
+                handlePlayerClick(playerId);
+            });
+        }
+    });
+
+    // Individual player reset buttons
+    const resetButtons = document.querySelectorAll('.player-reset-btn');
+    resetButtons.forEach(btn => {
+        btn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const playerId = parseInt(btn.dataset.playerId);
+            handlePlayerReset(playerId);
+        });
+    });
+
+    // Global reset button
+    const resetAllBtn = document.getElementById('planner-reset-all-btn');
+    if (resetAllBtn) {
+        resetAllBtn.addEventListener('click', () => {
+            handleGlobalReset();
+        });
+    }
+}
+

--- a/frontend/src/planner/indicators.js
+++ b/frontend/src/planner/indicators.js
@@ -1,0 +1,225 @@
+/**
+ * Metric Indicators Rendering
+ * Sleek indicator cards showing team metrics with deltas
+ */
+
+import { formatDecimal } from '../utils.js';
+
+/**
+ * Render metric indicators row
+ * @param {Object} originalMetrics - Original team metrics
+ * @param {Object} currentMetrics - Current team metrics (after changes)
+ * @returns {string} HTML string
+ */
+export function renderMetricIndicators(originalMetrics, currentMetrics) {
+    if (!originalMetrics || !currentMetrics) {
+        return '';
+    }
+
+    const deltas = calculateDeltas(originalMetrics, currentMetrics);
+
+    return `
+        <div style="
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background: var(--bg-secondary);
+            border-radius: 8px;
+        ">
+            <div style="
+                font-size: 0.75rem;
+                font-weight: 600;
+                color: var(--text-secondary);
+                margin-bottom: 0.75rem;
+            ">
+                Team Metrics
+            </div>
+            <div style="
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+                gap: 0.5rem;
+            ">
+                ${renderIndicatorCard('Avg PPM', deltas.avgPPM, 'ppm')}
+                ${renderIndicatorCard('Avg FDR', deltas.avgFDR, 'fdr')}
+                ${renderIndicatorCard('Avg Form', deltas.avgForm, 'form')}
+                ${renderIndicatorCard('Exp Pts', deltas.expectedPoints, 'points')}
+                ${renderIndicatorCard('Risk', deltas.riskCount, 'risk')}
+                ${renderIndicatorCard('Budget', deltas.budget, 'budget')}
+            </div>
+        </div>
+    `;
+}
+
+/**
+ * Render a single indicator card
+ * @param {string} label - Metric label
+ * @param {Object} delta - Delta object with value, delta, direction
+ * @param {string} type - Metric type for special formatting
+ * @returns {string} HTML string
+ */
+function renderIndicatorCard(label, delta, type) {
+    if (!delta) return '';
+
+    const { value, delta: deltaValue, direction } = delta;
+    
+    // Format value based on type
+    let displayValue = formatValue(value, type);
+    
+    // Format delta
+    const deltaDisplay = formatDelta(deltaValue, type);
+    const deltaColor = getDeltaColor(direction);
+    const deltaIcon = getDeltaIcon(direction);
+
+    return `
+        <div style="
+            background: var(--bg-primary);
+            padding: 0.5rem;
+            border-radius: 6px;
+            text-align: center;
+            border: 1px solid var(--border-color);
+        ">
+            <div style="
+                font-size: 0.6rem;
+                color: var(--text-secondary);
+                margin-bottom: 0.25rem;
+            ">
+                ${label}
+            </div>
+            <div style="
+                font-size: 0.85rem;
+                font-weight: 700;
+                color: var(--text-primary);
+                margin-bottom: 0.15rem;
+            ">
+                ${displayValue}
+            </div>
+            ${deltaValue !== 0 ? `
+                <div style="
+                    font-size: 0.65rem;
+                    color: ${deltaColor};
+                    font-weight: 600;
+                ">
+                    ${deltaIcon} ${deltaDisplay}
+                </div>
+            ` : `
+                <div style="
+                    font-size: 0.65rem;
+                    color: var(--text-tertiary);
+                ">
+                    —
+                </div>
+            `}
+        </div>
+    `;
+}
+
+/**
+ * Calculate deltas for all metrics
+ * @param {Object} original - Original metrics
+ * @param {Object} current - Current metrics
+ * @returns {Object} Deltas object
+ */
+function calculateDeltas(original, current) {
+    return {
+        avgPPM: {
+            value: current.avgPPM,
+            delta: current.avgPPM - original.avgPPM,
+            direction: current.avgPPM > original.avgPPM ? 'up' : 
+                      current.avgPPM < original.avgPPM ? 'down' : 'neutral'
+        },
+        avgFDR: {
+            value: current.avgFDR,
+            delta: current.avgFDR - original.avgFDR,
+            direction: current.avgFDR < original.avgFDR ? 'up' : // Lower FDR is better
+                       current.avgFDR > original.avgFDR ? 'down' : 'neutral'
+        },
+        avgForm: {
+            value: current.avgForm,
+            delta: current.avgForm - original.avgForm,
+            direction: current.avgForm > original.avgForm ? 'up' : 
+                      current.avgForm < original.avgForm ? 'down' : 'neutral'
+        },
+        expectedPoints: {
+            value: current.expectedPoints,
+            delta: current.expectedPoints - original.expectedPoints,
+            direction: current.expectedPoints > original.expectedPoints ? 'up' : 
+                      current.expectedPoints < original.expectedPoints ? 'down' : 'neutral'
+        },
+        riskCount: {
+            value: `${current.riskCount.high}🔴 ${current.riskCount.medium}🟠`,
+            delta: (current.riskCount.high + current.riskCount.medium) - 
+                   (original.riskCount.high + original.riskCount.medium),
+            direction: (current.riskCount.high + current.riskCount.medium) < 
+                       (original.riskCount.high + original.riskCount.medium) ? 'up' :
+                       (current.riskCount.high + current.riskCount.medium) > 
+                       (original.riskCount.high + original.riskCount.medium) ? 'down' : 'neutral'
+        },
+        budget: {
+            value: current.budget || 0,
+            delta: (current.budget || 0) - (original.budget || 0),
+            direction: (current.budget || 0) > (original.budget || 0) ? 'up' :
+                       (current.budget || 0) < (original.budget || 0) ? 'down' : 'neutral'
+        }
+    };
+}
+
+/**
+ * Format value based on type
+ * @param {number} value - Value to format
+ * @param {string} type - Metric type
+ * @returns {string} Formatted value
+ */
+function formatValue(value, type) {
+    if (type === 'risk') {
+        return value; // Already formatted as string
+    }
+    if (type === 'budget') {
+        return `£${(value / 10).toFixed(1)}m`;
+    }
+    if (type === 'points') {
+        return formatDecimal(value);
+    }
+    return formatDecimal(value);
+}
+
+/**
+ * Format delta value
+ * @param {number} delta - Delta value
+ * @param {string} type - Metric type
+ * @returns {string} Formatted delta
+ */
+function formatDelta(delta, type) {
+    if (type === 'budget') {
+        const absDelta = Math.abs(delta);
+        const sign = delta >= 0 ? '+' : '-';
+        return `${sign}£${(absDelta / 10).toFixed(1)}m`;
+    }
+    if (type === 'points') {
+        const sign = delta >= 0 ? '+' : '';
+        return `${sign}${formatDecimal(delta)}`;
+    }
+    const sign = delta >= 0 ? '+' : '';
+    return `${sign}${formatDecimal(delta, 1)}`;
+}
+
+/**
+ * Get color for delta direction
+ * @param {string} direction - 'up', 'down', or 'neutral'
+ * @returns {string} Color hex
+ */
+function getDeltaColor(direction) {
+    if (direction === 'up') return '#22c55e'; // Green for improvement
+    if (direction === 'down') return '#ef4444'; // Red for worse
+    return 'var(--text-tertiary)'; // Gray for neutral
+}
+
+/**
+ * Get icon for delta direction
+ * @param {string} direction - 'up', 'down', or 'neutral'
+ * @returns {string} Icon/arrow
+ */
+function getDeltaIcon(direction) {
+    if (direction === 'up') return '↑';
+    if (direction === 'down') return '↓';
+    return '—';
+}
+

--- a/frontend/src/planner/metrics.js
+++ b/frontend/src/planner/metrics.js
@@ -1,0 +1,192 @@
+/**
+ * Team Metrics Calculation
+ * Calculates team-level metrics before and after changes
+ */
+
+import { getAllPlayers } from '../data.js';
+import { calculateSquadAverages } from '../myTeam/teamSummaryHelpers.js';
+import { calculateFixtureDifficulty } from '../fixtures.js';
+import { analyzePlayerRisks, hasHighRisk, hasMediumRisk } from '../risk.js';
+import { currentGW } from '../data.js';
+
+/**
+ * Calculate team metrics for a given squad
+ * @param {Array} picks - Team picks array
+ * @param {number} gameweek - Current gameweek
+ * @returns {Object} Team metrics
+ */
+export function calculateTeamMetrics(picks, gameweek) {
+    if (!picks || picks.length === 0) {
+        return getEmptyMetrics();
+    }
+
+    const allPlayers = getAllPlayers();
+    const players = picks
+        .map(pick => allPlayers.find(p => p.id === pick.element))
+        .filter(p => p !== undefined);
+
+    if (players.length === 0) {
+        return getEmptyMetrics();
+    }
+
+    // Use existing squad averages calculation
+    const squadAverages = calculateSquadAverages(picks, gameweek);
+
+    // Calculate expected points (sum of ep_next for next 5 GWs)
+    let totalExpectedPoints = 0;
+    players.forEach(player => {
+        const epNext = parseFloat(player.ep_next) || 0;
+        // For simplicity, use ep_next * 5 for next 5 GWs
+        // In reality, we'd need to calculate per-GW, but ep_next is FPL's prediction
+        totalExpectedPoints += epNext * 5;
+    });
+
+    // Count risks
+    let highRiskCount = 0;
+    let mediumRiskCount = 0;
+    let lowRiskCount = 0;
+
+    players.forEach(player => {
+        const risks = analyzePlayerRisks(player);
+        if (hasHighRisk(risks)) {
+            highRiskCount++;
+        } else if (hasMediumRisk(risks)) {
+            mediumRiskCount++;
+        } else if (risks.length > 0) {
+            lowRiskCount++;
+        }
+    });
+
+    return {
+        avgPPM: squadAverages.avgPPM,
+        avgFDR: squadAverages.avgFDR,
+        avgForm: calculateAverageForm(players),
+        expectedPoints: totalExpectedPoints,
+        riskCount: {
+            high: highRiskCount,
+            medium: mediumRiskCount,
+            low: lowRiskCount
+        },
+        avgOwnership: squadAverages.avgOwnership,
+        avgMinPercent: squadAverages.avgMinPercent
+    };
+}
+
+/**
+ * Calculate projected team metrics after changes
+ * @param {Array} originalPicks - Original team picks
+ * @param {Array} changes - Array of {out: playerId, in: playerId}
+ * @param {number} gameweek - Current gameweek
+ * @returns {Object} Projected team metrics
+ */
+export function calculateProjectedTeamMetrics(originalPicks, changes, gameweek) {
+    if (!changes || changes.length === 0) {
+        return calculateTeamMetrics(originalPicks, gameweek);
+    }
+
+    // Create projected squad
+    const projectedPicks = originalPicks.map(pick => ({ ...pick }));
+    
+    changes.forEach(change => {
+        const outIndex = projectedPicks.findIndex(p => p.element === change.out);
+        if (outIndex >= 0) {
+            projectedPicks[outIndex] = {
+                ...projectedPicks[outIndex],
+                element: change.in
+            };
+        }
+    });
+
+    return calculateTeamMetrics(projectedPicks, gameweek);
+}
+
+/**
+ * Calculate average form across squad
+ * @param {Array} players - Player objects
+ * @returns {number} Average form
+ */
+function calculateAverageForm(players) {
+    if (players.length === 0) return 0;
+    
+    const totalForm = players.reduce((sum, player) => {
+        return sum + (parseFloat(player.form) || 0);
+    }, 0);
+    
+    return totalForm / players.length;
+}
+
+/**
+ * Get empty metrics object
+ * @returns {Object} Empty metrics
+ */
+function getEmptyMetrics() {
+    return {
+        avgPPM: 0,
+        avgFDR: 0,
+        avgForm: 0,
+        expectedPoints: 0,
+        riskCount: {
+            high: 0,
+            medium: 0,
+            low: 0
+        },
+        avgOwnership: 0,
+        avgMinPercent: 0
+    };
+}
+
+/**
+ * Calculate delta between two metrics
+ * @param {Object} current - Current metrics
+ * @param {Object} original - Original metrics
+ * @returns {Object} Delta metrics with direction indicators
+ */
+export function calculateMetricsDelta(current, original) {
+    return {
+        avgPPM: {
+            value: current.avgPPM,
+            delta: current.avgPPM - original.avgPPM,
+            direction: current.avgPPM > original.avgPPM ? 'up' : 
+                      current.avgPPM < original.avgPPM ? 'down' : 'neutral'
+        },
+        avgFDR: {
+            value: current.avgFDR,
+            delta: current.avgFDR - original.avgFDR,
+            direction: current.avgFDR < original.avgFDR ? 'up' : // Lower FDR is better
+                       current.avgFDR > original.avgFDR ? 'down' : 'neutral'
+        },
+        avgForm: {
+            value: current.avgForm,
+            delta: current.avgForm - original.avgForm,
+            direction: current.avgForm > original.avgForm ? 'up' : 
+                      current.avgForm < original.avgForm ? 'down' : 'neutral'
+        },
+        expectedPoints: {
+            value: current.expectedPoints,
+            delta: current.expectedPoints - original.expectedPoints,
+            direction: current.expectedPoints > original.expectedPoints ? 'up' : 
+                      current.expectedPoints < original.expectedPoints ? 'down' : 'neutral'
+        },
+        riskCount: {
+            high: {
+                value: current.riskCount.high,
+                delta: current.riskCount.high - original.riskCount.high,
+                direction: current.riskCount.high < original.riskCount.high ? 'up' : // Fewer risks is better
+                           current.riskCount.high > original.riskCount.high ? 'down' : 'neutral'
+            },
+            medium: {
+                value: current.riskCount.medium,
+                delta: current.riskCount.medium - original.riskCount.medium,
+                direction: current.riskCount.medium < original.riskCount.medium ? 'up' :
+                           current.riskCount.medium > original.riskCount.medium ? 'down' : 'neutral'
+            },
+            low: {
+                value: current.riskCount.low,
+                delta: current.riskCount.low - original.riskCount.low,
+                direction: current.riskCount.low < original.riskCount.low ? 'up' :
+                           current.riskCount.low > original.riskCount.low ? 'down' : 'neutral'
+            }
+        }
+    };
+}
+

--- a/frontend/src/planner/replacementPage.js
+++ b/frontend/src/planner/replacementPage.js
@@ -1,0 +1,288 @@
+/**
+ * Player Replacement Page
+ * Shows recommended replacements and full position list
+ */
+
+import { getAllPlayers, getPlayerById } from '../data.js';
+import { findReplacements } from '../transferHelpers.js';
+import { getFixtures, calculateFixtureDifficulty } from '../fixtures.js';
+import {
+    getPositionShort,
+    formatCurrency,
+    escapeHtml,
+    calculatePPM,
+    getDifficultyClass,
+    getTeamShortName,
+    formatDecimal,
+    getFormHeatmap,
+    getHeatmapStyle
+} from '../utils.js';
+import { plannerState } from './state.js';
+import { currentGW } from '../data.js';
+
+/**
+ * Render player replacement page
+ * @param {number} playerId - Player ID to replace
+ * @returns {string} HTML string
+ */
+export function renderPlayerReplacementPage(playerId) {
+    const player = getPlayerById(playerId);
+    if (!player) {
+        return '<div>Player not found</div>';
+    }
+
+    const currentSquad = plannerState.getCurrentSquad();
+    const initialPicks = plannerState.getInitialPicks();
+    const initialBank = plannerState.getInitialBank();
+    const initialValue = plannerState.getInitialValue();
+
+    // Create picks object for findReplacements
+    const picks = {
+        picks: initialPicks,
+        entry_history: {
+            bank: initialBank,
+            value: initialValue
+        }
+    };
+
+    // Get recommended replacements
+    const recommendations = findReplacements(player, picks, currentGW);
+
+    // Get all players in same position
+    const allPlayers = getAllPlayers();
+    const positionPlayers = allPlayers.filter(p => 
+        p.element_type === player.element_type && 
+        p.id !== playerId &&
+        !currentSquad.some(pick => pick.element === p.id)
+    );
+
+    // Sort by form (default)
+    positionPlayers.sort((a, b) => {
+        const formA = parseFloat(a.form) || 0;
+        const formB = parseFloat(b.form) || 0;
+        return formB - formA;
+    });
+
+    const next5GWs = [currentGW + 1, currentGW + 2, currentGW + 3, currentGW + 4, currentGW + 5];
+    const priceDiff = player.now_cost;
+
+    return `
+        <div style="padding: 0.5rem;">
+            ${renderReplacementHeader(player)}
+            ${renderRecommendedReplacements(recommendations, player, next5GWs, priceDiff)}
+            ${renderAllPositionPlayers(positionPlayers, player, next5GWs, priceDiff)}
+        </div>
+    `;
+}
+
+/**
+ * Render replacement page header
+ * @param {Object} player - Player being replaced
+ * @returns {string} HTML string
+ */
+function renderReplacementHeader(player) {
+    return `
+        <div style="
+            position: sticky;
+            top: calc(3.5rem + env(safe-area-inset-top));
+            background: var(--bg-primary);
+            z-index: 100;
+            padding: 0.75rem 0;
+            border-bottom: 2px solid var(--border-color);
+            margin-bottom: 0.75rem;
+        ">
+            <div style="display: flex; align-items: center; gap: 0.75rem;">
+                <button
+                    id="replacement-back-btn"
+                    style="
+                        background: none;
+                        border: none;
+                        color: var(--text-primary);
+                        font-size: 1.2rem;
+                        cursor: pointer;
+                        padding: 0.25rem;
+                    "
+                >
+                    <i class="fas fa-arrow-left"></i>
+                </button>
+                <div>
+                    <h1 style="font-size: 1.1rem; font-weight: 700; color: var(--text-primary); margin: 0;">
+                        Replace: ${escapeHtml(player.web_name)}
+                    </h1>
+                    <p style="font-size: 0.7rem; color: var(--text-secondary); margin: 0.2rem 0 0 0;">
+                        ${getPositionShort(player)} • ${formatCurrency(player.now_cost)}
+                    </p>
+                </div>
+            </div>
+        </div>
+    `;
+}
+
+/**
+ * Render recommended replacements section
+ * @param {Array} recommendations - Recommended replacements
+ * @param {Object} originalPlayer - Original player
+ * @param {Array} next5GWs - Next 5 gameweeks
+ * @param {number} originalPrice - Original player price
+ * @returns {string} HTML string
+ */
+function renderRecommendedReplacements(recommendations, originalPlayer, next5GWs, originalPrice) {
+    if (recommendations.length === 0) {
+        return '';
+    }
+
+    return `
+        <div style="margin-bottom: 1.5rem;">
+            <h2 style="
+                font-size: 0.9rem;
+                font-weight: 600;
+                color: var(--text-primary);
+                margin-bottom: 0.75rem;
+            ">
+                <i class="fas fa-star" style="color: var(--primary-color); margin-right: 0.5rem;"></i>
+                Recommended Replacements
+            </h2>
+            ${renderReplacementTable(recommendations.map(r => r.player), originalPlayer, next5GWs, originalPrice, true)}
+        </div>
+    `;
+}
+
+/**
+ * Render all position players section
+ * @param {Array} players - All players in position
+ * @param {Object} originalPlayer - Original player
+ * @param {Array} next5GWs - Next 5 gameweeks
+ * @param {number} originalPrice - Original player price
+ * @returns {string} HTML string
+ */
+function renderAllPositionPlayers(players, originalPlayer, next5GWs, originalPrice) {
+    return `
+        <div>
+            <h2 style="
+                font-size: 0.9rem;
+                font-weight: 600;
+                color: var(--text-primary);
+                margin-bottom: 0.75rem;
+            ">
+                All ${getPositionShort(originalPlayer)} Players
+            </h2>
+            ${renderReplacementTable(players, originalPlayer, next5GWs, originalPrice, false)}
+        </div>
+    `;
+}
+
+/**
+ * Render replacement table (using existing table styling)
+ * @param {Array} players - Players to display
+ * @param {Object} originalPlayer - Original player
+ * @param {Array} next5GWs - Next 5 gameweeks
+ * @param {number} originalPrice - Original player price
+ * @param {boolean} isRecommended - Whether this is recommended section
+ * @returns {string} HTML string
+ */
+function renderReplacementTable(players, originalPlayer, next5GWs, originalPrice, isRecommended) {
+    if (players.length === 0) {
+        return `
+            <div style="
+                text-align: center;
+                padding: 2rem;
+                color: var(--text-secondary);
+                font-size: 0.85rem;
+            ">
+                No players found
+            </div>
+        `;
+    }
+
+    return `
+        <div style="
+            background: var(--bg-secondary);
+            border-radius: 8px;
+            overflow: hidden;
+        ">
+            <div style="overflow-x: auto; -webkit-overflow-scrolling: touch;">
+                <table style="width: 100%; font-size: 0.75rem; border-collapse: collapse;">
+                    <thead style="background: var(--bg-tertiary);">
+                        <tr>
+                            <th style="position: sticky; left: 0; background: var(--bg-tertiary); z-index: 10; text-align: left; padding: 0.5rem; min-width: 140px;">Player</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">FDR</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Form</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 70px;">Price</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Diff</th>
+                            ${next5GWs.map(gw => `<th style="text-align: center; padding: 0.5rem; min-width: 60px;">GW${gw}</th>`).join('')}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        ${players.map((player, idx) => {
+                            const next5Fixtures = getFixtures(player.team, 5, false);
+                            const avgFDR = calculateFixtureDifficulty(player.team, 5);
+                            const formHeatmap = getFormHeatmap(player.form);
+                            const formStyle = getHeatmapStyle(formHeatmap);
+                            const rowBg = idx % 2 === 0 ? 'var(--bg-primary)' : 'var(--bg-secondary)';
+                            const fdrColor = avgFDR <= 2.5 ? '#22c55e' : avgFDR <= 3.5 ? '#eab308' : '#ef4444';
+                            const priceDiff = player.now_cost - originalPrice;
+                            const diffSign = priceDiff >= 0 ? '+' : '';
+                            const diffColor = priceDiff <= 0 ? '#22c55e' : '#ef4444';
+
+                            return `
+                                <tr 
+                                    class="replacement-player-row"
+                                    data-player-id="${player.id}"
+                                    data-original-id="${originalPlayer.id}"
+                                    style="
+                                        background: ${rowBg};
+                                        cursor: pointer;
+                                        transition: background 0.2s;
+                                    "
+                                    onmouseover="this.style.background='var(--bg-tertiary)'"
+                                    onmouseout="this.style.background='${rowBg}'"
+                                >
+                                    <td style="
+                                        position: sticky;
+                                        left: 0;
+                                        background: ${rowBg};
+                                        z-index: 5;
+                                        padding: 0.5rem;
+                                        border-right: 1px solid var(--border-color);
+                                    ">
+                                        <div style="display: flex; align-items: center; gap: 0.3rem;">
+                                            <span style="font-size: 0.6rem; color: var(--text-secondary);">${getPositionShort(player)}</span>
+                                            <strong style="font-size: 0.7rem;">${escapeHtml(player.web_name)}</strong>
+                                        </div>
+                                        <div style="font-size: 0.6rem; color: var(--text-secondary); margin-top: 0.1rem;">
+                                            ${getTeamShortName(player.team)}
+                                        </div>
+                                    </td>
+                                    <td style="text-align: center; padding: 0.5rem; color: ${fdrColor}; font-weight: 700;">
+                                        ${avgFDR.toFixed(1)}
+                                    </td>
+                                    <td style="text-align: center; padding: 0.5rem; background: ${formStyle.background}; color: ${formStyle.color}; font-weight: 600;">
+                                        ${formatDecimal(player.form)}
+                                    </td>
+                                    <td style="text-align: center; padding: 0.5rem;">
+                                        ${formatCurrency(player.now_cost)}
+                                    </td>
+                                    <td style="text-align: center; padding: 0.5rem; color: ${diffColor}; font-weight: 600;">
+                                        ${diffSign}£${Math.abs(priceDiff / 10).toFixed(1)}m
+                                    </td>
+                                    ${next5Fixtures.map(fix => {
+                                        const fdrClass = getDifficultyClass(fix.difficulty);
+                                        return `
+                                            <td style="text-align: center; padding: 0.5rem;">
+                                                <span class="${fdrClass}" style="display: inline-block; width: 52px; padding: 0.2rem 0.3rem; border-radius: 3px; font-weight: 600; font-size: 0.65rem; text-align: center;">
+                                                    ${fix.opponent}
+                                                </span>
+                                            </td>
+                                        `;
+                                    }).join('')}
+                                    ${next5Fixtures.length < 5 ? Array(5 - next5Fixtures.length).fill('<td style="text-align: center; padding: 0.5rem;">—</td>').join('') : ''}
+                                </tr>
+                            `;
+                        }).join('')}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    `;
+}
+

--- a/frontend/src/planner/state.js
+++ b/frontend/src/planner/state.js
@@ -1,0 +1,160 @@
+/**
+ * Planner State Management
+ * In-memory state for sandbox team changes (no persistence)
+ */
+
+/**
+ * Planner state object
+ */
+class PlannerState {
+    constructor() {
+        this.initialSquad = null; // Original team snapshot (for AI insights)
+        this.initialPicks = null; // Original picks data
+        this.changes = []; // Array of {out: playerId, in: playerId, timestamp}
+        this.initialBank = 0; // Original bank balance
+        this.initialValue = 0; // Original team value
+    }
+
+    /**
+     * Initialize state with original team data
+     * @param {Array} picks - Original team picks
+     * @param {number} bank - Original bank balance
+     * @param {number} value - Original team value
+     */
+    initialize(initialSquad, picks, bank, value) {
+        this.initialSquad = initialSquad.map(p => ({ ...p })); // Deep copy
+        this.initialPicks = picks.map(p => ({ ...p })); // Deep copy
+        this.initialBank = bank;
+        this.initialValue = value;
+        this.changes = [];
+    }
+
+    /**
+     * Get initial squad (for AI insights)
+     * @returns {Array} Original squad
+     */
+    getInitialSquad() {
+        return this.initialSquad;
+    }
+
+    /**
+     * Get initial picks
+     * @returns {Array} Original picks
+     */
+    getInitialPicks() {
+        return this.initialPicks;
+    }
+
+    /**
+     * Get all changes made
+     * @returns {Array} Changes array
+     */
+    getChanges() {
+        return this.changes;
+    }
+
+    /**
+     * Add a change (swap player out for player in)
+     * @param {number} playerOutId - Player being removed
+     * @param {number} playerInId - Player being added
+     */
+    addChange(playerOutId, playerInId) {
+        // Remove any existing change for this player out
+        this.changes = this.changes.filter(c => c.out !== playerOutId);
+        
+        // Add new change
+        this.changes.push({
+            out: playerOutId,
+            in: playerInId,
+            timestamp: new Date().toISOString()
+        });
+    }
+
+    /**
+     * Remove a specific change
+     * @param {number} playerOutId - Player ID to reset
+     */
+    removeChange(playerOutId) {
+        this.changes = this.changes.filter(c => c.out !== playerOutId);
+    }
+
+    /**
+     * Get change for a specific player
+     * @param {number} playerId - Player ID
+     * @returns {Object|null} Change object or null
+     */
+    getChangeForPlayer(playerId) {
+        return this.changes.find(c => c.out === playerId) || null;
+    }
+
+    /**
+     * Check if a player has been modified
+     * @param {number} playerId - Player ID
+     * @returns {boolean} True if modified
+     */
+    isPlayerModified(playerId) {
+        return this.changes.some(c => c.out === playerId);
+    }
+
+    /**
+     * Get current squad (with changes applied)
+     * @returns {Array} Current squad picks
+     */
+    getCurrentSquad() {
+        if (!this.initialPicks) return [];
+        
+        const currentSquad = this.initialPicks.map(pick => ({ ...pick }));
+        
+        // Apply changes
+        this.changes.forEach(change => {
+            const outIndex = currentSquad.findIndex(p => p.element === change.out);
+            if (outIndex >= 0) {
+                // Replace player
+                currentSquad[outIndex] = {
+                    ...currentSquad[outIndex],
+                    element: change.in
+                };
+            }
+        });
+        
+        return currentSquad;
+    }
+
+    /**
+     * Reset all changes
+     */
+    resetAll() {
+        this.changes = [];
+    }
+
+    /**
+     * Reset state completely
+     */
+    clear() {
+        this.initialSquad = null;
+        this.initialPicks = null;
+        this.changes = [];
+        this.initialBank = 0;
+        this.initialValue = 0;
+    }
+
+    /**
+     * Get initial bank balance
+     * @returns {number} Bank balance
+     */
+    getInitialBank() {
+        return this.initialBank;
+    }
+
+    /**
+     * Get initial team value
+     * @returns {number} Team value
+     */
+    getInitialValue() {
+        return this.initialValue;
+    }
+}
+
+// Export singleton instance
+export const plannerState = new PlannerState();
+


### PR DESCRIPTION
- Add modular planner state management (in-memory only)
- Implement team metrics calculation with before/after comparison
- Add sleek metric indicators showing real-time deltas
- Create player replacement page with recommendations
- Add cost/step calculation for transfers
- Integrate AI insights based on initial team snapshot
- Add visual indicators for modified players
- Implement individual and global reset functionality
- Preserve existing UI/styling, use existing table patterns
- Add routing for replacement page (#planner/replace/{playerId})

All code is modularized for easy debugging and maintenance.