### PR TITLE
feat: align planner AI + metrics with shared pipeline

### DIFF
--- a/frontend/src/planner/aiInsights.js
+++ b/frontend/src/planner/aiInsights.js
@@ -3,7 +3,7 @@
  * Loads AI insights based on initial team snapshot (not changes)
  */
 
-import { aiInsights } from '../aiInsights.js';
+import { loadAndRenderInsights } from '../renderInsightBanner.js';
 import { plannerState } from './state.js';
 import { currentGW } from '../data.js';
 import { getAllPlayers } from '../data.js';
@@ -13,37 +13,43 @@ import { getTeamsWithBestFixtures, getTeamsWithWorstFixtures } from '../fixtures
 import { calculatePPM } from '../utils.js';
 
 /**
- * Load AI insights for planner
- * Uses initial team snapshot only (not changes)
+ * Load AI insights for planner using shared banner pipeline
  */
 export async function loadPlannerAIInsights() {
     const container = document.getElementById('planner-ai-insights');
-    if (!container) {
+    if (!container) return;
+
+    if (!plannerState.isInitialized()) {
+        container.innerHTML = `
+            <div style="
+                background: var(--bg-primary);
+                border: 2px solid #fb923c;
+                border-radius: 12px;
+                padding: 0.75rem;
+                margin-bottom: 1rem;
+                text-align: center;
+                color: #fb923c;
+                font-size: 0.8rem;
+            ">
+                Load your team to generate planner insights.
+            </div>
+        `;
         return;
     }
 
-    const initialSquad = plannerState.getInitialSquad();
     const initialPicks = plannerState.getInitialPicks();
-    
-    if (!initialSquad || !initialPicks) {
-        container.innerHTML = renderPlannerInsightsError('No team snapshot available yet.');
-        return;
-    }
-
     const allPlayers = getAllPlayers();
     const players = initialPicks
         .map(pick => allPlayers.find(p => p.id === pick.element))
-        .filter(p => p !== undefined);
+        .filter(Boolean);
 
-    if (players.length === 0) {
-        return;
-    }
-
-    // Calculate team metrics
     const squadAverages = calculateSquadAverages(initialPicks, currentGW);
 
-    // Find problem players
     const problemPlayers = [];
+    let highRiskCount = 0;
+    let mediumRiskCount = 0;
+    let lowRiskCount = 0;
+
     players.forEach(player => {
         const risks = analyzePlayerRisks(player);
         if (hasHighRisk(risks) || hasMediumRisk(risks)) {
@@ -54,29 +60,12 @@ export async function loadPlannerAIInsights() {
                 severity: hasHighRisk(risks) ? 'high' : 'medium'
             });
         }
+
+        if (hasHighRisk(risks)) highRiskCount++;
+        else if (hasMediumRisk(risks)) mediumRiskCount++;
+        else if (risks.length > 0) lowRiskCount++;
     });
 
-    // Count risks
-    let highRiskCount = 0;
-    let mediumRiskCount = 0;
-    let lowRiskCount = 0;
-
-    players.forEach(player => {
-        const risks = analyzePlayerRisks(player);
-        if (hasHighRisk(risks)) {
-            highRiskCount++;
-        } else if (hasMediumRisk(risks)) {
-            mediumRiskCount++;
-        } else if (risks.length > 0) {
-            lowRiskCount++;
-        }
-    });
-
-    // Get team fixture analysis
-    const teamsWithBestFixtures = getTeamsWithBestFixtures(10, 5);
-    const teamsWithWorstFixtures = getTeamsWithWorstFixtures(10, 5);
-
-    // Prepare context data for AI
     const contextData = {
         currentSquad: players.map(p => ({
             name: p.web_name,
@@ -100,13 +89,12 @@ export async function loadPlannerAIInsights() {
             low: lowRiskCount
         },
         teamAnalysis: {
-            bestFixtures: teamsWithBestFixtures,
-            worstFixtures: teamsWithWorstFixtures,
+            bestFixtures: getTeamsWithBestFixtures(10, 5),
+            worstFixtures: getTeamsWithWorstFixtures(10, 5),
             currentGW
         }
     };
 
-    // Build context for AI service
     const context = {
         page: 'planner',
         tab: 'sandbox',
@@ -115,115 +103,13 @@ export async function loadPlannerAIInsights() {
         data: contextData
     };
 
-    // Check if mobile
     const isMobile = window.innerWidth <= 767;
 
-    // Show loading state
-    container.innerHTML = renderPlannerInsightsLoading();
-
-    try {
-        const insights = await aiInsights.getInsights(context);
-        container.innerHTML = renderPlannerInsights(insights, isMobile);
-    } catch (error) {
-        console.error('Failed to load planner AI insights:', error);
-        container.innerHTML = renderPlannerInsightsError('Unable to load AI guidance right now.');
-    }
-}
-
-function renderPlannerInsights(insights, isMobile) {
-    const items = (insights?.plannerInsights && insights.plannerInsights.length > 0)
-        ? insights.plannerInsights
-        : (insights?.categories?.Overview || []);
-
-    return `
-        <div style="
-            background: var(--bg-primary);
-            border: 2px solid var(--accent-color);
-            border-radius: 12px;
-            padding: ${isMobile ? '0.75rem' : '1rem'};
-            margin-bottom: 1rem;
-            box-shadow: 0 4px 12px var(--shadow);
-        ">
-            <div style="
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
-                margin-bottom: 0.5rem;
-                gap: 0.5rem;
-            ">
-                <h3 style="
-                    color: var(--accent-color);
-                    font-weight: 700;
-                    font-size: ${isMobile ? '0.9rem' : '1rem'};
-                    margin: 0;
-                ">
-                    🤖 Planner Insights
-                </h3>
-                <span style="
-                    font-size: 0.65rem;
-                    color: var(--text-secondary);
-                ">
-                    Snapshot guidance (initial team)
-                </span>
-            </div>
-            <ul style="
-                list-style: none;
-                padding: 0;
-                margin: 0;
-                display: flex;
-                flex-direction: column;
-                gap: 0.6rem;
-            ">
-                ${items.map(item => `
-                    <li style="
-                        padding: 0.6rem 0.7rem;
-                        background: var(--bg-secondary);
-                        border-radius: 8px;
-                        font-size: ${isMobile ? '0.8rem' : '0.9rem'};
-                        line-height: 1.4;
-                        color: var(--text-primary);
-                        border-left: 3px solid var(--accent-color);
-                    ">
-                        ${item}
-                    </li>
-                `).join('')}
-            </ul>
-        </div>
-    `;
-}
-
-function renderPlannerInsightsLoading() {
-    return `
-        <div style="
-            background: var(--bg-primary);
-            border: 2px solid var(--border-color);
-            border-radius: 12px;
-            padding: 1rem;
-            margin-bottom: 1rem;
-            text-align: center;
-        ">
-            <i class="fas fa-spinner fa-spin" style="color: var(--accent-color);"></i>
-            <span style="margin-left: 0.5rem; color: var(--text-secondary);">
-                Generating planner guidance...
-            </span>
-        </div>
-    `;
-}
-
-function renderPlannerInsightsError(message) {
-    return `
-        <div style="
-            background: var(--bg-primary);
-            border: 2px solid #fb923c;
-            border-radius: 12px;
-            padding: 1rem;
-            margin-bottom: 1rem;
-            color: #fb923c;
-            font-size: 0.85rem;
-            text-align: center;
-        ">
-            ${message}
-        </div>
-    `;
+    await loadAndRenderInsights(context, 'planner-ai-insights', isMobile, {
+        hideTabs: true,
+        customTitle: '🤖 Planner Insights',
+        customSubtitle: 'Snapshot guidance at GW ' + currentGW,
+        preferredCategory: 'Planner'
+    });
 }
 

--- a/frontend/src/planner/metrics.js
+++ b/frontend/src/planner/metrics.js
@@ -5,8 +5,6 @@
 
 import { getAllPlayers } from '../data.js';
 import { calculateSquadAverages } from '../myTeam/teamSummaryHelpers.js';
-import { calculateFixtureDifficulty } from '../fixtures.js';
-import { analyzePlayerRisks, hasHighRisk, hasMediumRisk } from '../risk.js';
 import { currentGW } from '../data.js';
 
 /**
@@ -41,34 +39,14 @@ export function calculateTeamMetrics(picks, gameweek) {
         totalExpectedPoints += epNext * 5;
     });
 
-    // Count risks
-    let highRiskCount = 0;
-    let mediumRiskCount = 0;
-    let lowRiskCount = 0;
-
-    players.forEach(player => {
-        const risks = analyzePlayerRisks(player);
-        if (hasHighRisk(risks)) {
-            highRiskCount++;
-        } else if (hasMediumRisk(risks)) {
-            mediumRiskCount++;
-        } else if (risks.length > 0) {
-            lowRiskCount++;
-        }
-    });
-
     return {
         avgPPM: squadAverages.avgPPM,
         avgFDR: squadAverages.avgFDR,
         avgForm: calculateAverageForm(players),
         expectedPoints: totalExpectedPoints,
-        riskCount: {
-            high: highRiskCount,
-            medium: mediumRiskCount,
-            low: lowRiskCount
-        },
         avgOwnership: squadAverages.avgOwnership,
-        avgMinPercent: squadAverages.avgMinPercent
+        avgMinPercent: squadAverages.avgMinPercent,
+        avgXGI: calculateAverageXGI(players)
     };
 }
 
@@ -125,13 +103,9 @@ function getEmptyMetrics() {
         avgFDR: 0,
         avgForm: 0,
         expectedPoints: 0,
-        riskCount: {
-            high: 0,
-            medium: 0,
-            low: 0
-        },
         avgOwnership: 0,
-        avgMinPercent: 0
+        avgMinPercent: 0,
+        avgXGI: 0
     };
 }
 
@@ -143,50 +117,35 @@ function getEmptyMetrics() {
  */
 export function calculateMetricsDelta(current, original) {
     return {
-        avgPPM: {
-            value: current.avgPPM,
-            delta: current.avgPPM - original.avgPPM,
-            direction: current.avgPPM > original.avgPPM ? 'up' : 
-                      current.avgPPM < original.avgPPM ? 'down' : 'neutral'
-        },
-        avgFDR: {
-            value: current.avgFDR,
-            delta: current.avgFDR - original.avgFDR,
-            direction: current.avgFDR < original.avgFDR ? 'up' : // Lower FDR is better
-                       current.avgFDR > original.avgFDR ? 'down' : 'neutral'
-        },
-        avgForm: {
-            value: current.avgForm,
-            delta: current.avgForm - original.avgForm,
-            direction: current.avgForm > original.avgForm ? 'up' : 
-                      current.avgForm < original.avgForm ? 'down' : 'neutral'
-        },
-        expectedPoints: {
-            value: current.expectedPoints,
-            delta: current.expectedPoints - original.expectedPoints,
-            direction: current.expectedPoints > original.expectedPoints ? 'up' : 
-                      current.expectedPoints < original.expectedPoints ? 'down' : 'neutral'
-        },
-        riskCount: {
-            high: {
-                value: current.riskCount.high,
-                delta: current.riskCount.high - original.riskCount.high,
-                direction: current.riskCount.high < original.riskCount.high ? 'up' : // Fewer risks is better
-                           current.riskCount.high > original.riskCount.high ? 'down' : 'neutral'
-            },
-            medium: {
-                value: current.riskCount.medium,
-                delta: current.riskCount.medium - original.riskCount.medium,
-                direction: current.riskCount.medium < original.riskCount.medium ? 'up' :
-                           current.riskCount.medium > original.riskCount.medium ? 'down' : 'neutral'
-            },
-            low: {
-                value: current.riskCount.low,
-                delta: current.riskCount.low - original.riskCount.low,
-                direction: current.riskCount.low < original.riskCount.low ? 'up' :
-                           current.riskCount.low > original.riskCount.low ? 'down' : 'neutral'
-            }
-        }
+        avgPPM: createDelta(current.avgPPM, original.avgPPM, true),
+        avgFDR: createDelta(current.avgFDR, original.avgFDR, false), // lower is better
+        avgForm: createDelta(current.avgForm, original.avgForm, true),
+        expectedPoints: createDelta(current.expectedPoints, original.expectedPoints, true),
+        avgOwnership: createDelta(current.avgOwnership, original.avgOwnership, true),
+        avgXGI: createDelta(current.avgXGI, original.avgXGI, true)
     };
+}
+
+function createDelta(currentValue, originalValue, higherIsBetter) {
+    const delta = currentValue - originalValue;
+    let direction = 'neutral';
+    if (delta !== 0) {
+        const improved = higherIsBetter ? delta > 0 : delta < 0;
+        direction = improved ? 'up' : 'down';
+    }
+    return {
+        value: currentValue,
+        delta,
+        direction
+    };
+}
+
+function calculateAverageXGI(players) {
+    if (!players.length) return 0;
+    const total = players.reduce((sum, player) => {
+        const xgi = parseFloat(player.expected_goal_involvements_per_90) || 0;
+        return sum + xgi;
+    }, 0);
+    return total / players.length;
 }
 

--- a/frontend/src/renderPlanner.js
+++ b/frontend/src/renderPlanner.js
@@ -126,10 +126,7 @@ export async function renderPlanner() {
         const changes = plannerState.getChanges();
         const projectedMetrics = calculateProjectedTeamMetrics(picks, changes, gwNumber);
         
-        // Add budget to metrics
         const costSummary = getCurrentCostSummary();
-        originalMetrics.budget = bank;
-        projectedMetrics.budget = costSummary.newBank;
 
         // Build page HTML
         const html = `


### PR DESCRIPTION
- Reuse shared AI insight banner with planner-specific prompt/category
- Support dynamic categories & tabless mode in insight banner renderer
- Rework planner metrics (Avg Own%, Avg xGI) and remove risk/budget cards
- Show squad metric deltas directly in replacement tables
- Refine replacement scoring (expected pts, xGI, risk penalties, team limits)
- Ensure sandbox state persists across planner render/replacement flow