### PR TITLE
fix: properly handle AI insights parse errors on mobile

### DIFF
--- a/backend/services/aiService.js
+++ b/backend/services/aiService.js
@@ -203,7 +203,9 @@ export function parseGeminiResponse(geminiData, gameweek, page) {
       gameweek: gameweek,
       categories: fallbackCategories,
       timestamp: Date.now(),
-      parseError: true
+      parseError: true,
+      error: true,
+      message: 'Failed to generate AI insights. Please try refreshing or check back later.'
     };
   }
 }


### PR DESCRIPTION
Previously, when the Gemini API response failed to parse, the backend would return fallback error messages within the categories object. The frontend would then render these as normal bullet points instead of showing an error banner with a retry button.

Changes:
- Backend: Set both `error: true` and `parseError: true` with clear message when parsing fails
- Frontend: Check for `parseError` flag in addition to `error` flag
- Frontend: Attach retry listener with force refresh for error states
- Frontend: Ensure retry button clears cache and fetches fresh data

This ensures users see a proper error banner with a working retry button instead of confusing fallback messages that look like real insights.

Fixes the issue where mobile users were seeing "AI insights temporarily unavailable" as bullet points instead of as an error state.