### PR TITLE
fix: resolve remaining mobile stats issues and chart axis scaling

### DIFF
--- a/frontend/src/charts/formVsPrice.js
+++ b/frontend/src/charts/formVsPrice.js
@@ -92,6 +92,13 @@ export async function renderFormVsPriceChart(contentContainer, echarts, position
     const option = createFormVsPriceChartOptions(positions, yAxisMax, isDark, textColor, gridColor);
 
     if (!echarts) return null;
+
+    // Dispose existing chart instance if it exists to prevent caching issues
+    const existingInstance = echarts.getInstanceByDom(chartContainer);
+    if (existingInstance) {
+        existingInstance.dispose();
+    }
+
     const chartInstance = echarts.init(chartContainer);
     if (!chartInstance) return null;
 

--- a/frontend/src/charts/minutesEfficiency.js
+++ b/frontend/src/charts/minutesEfficiency.js
@@ -109,6 +109,13 @@ export async function renderMinutesEfficiencyChart(contentContainer, echarts, po
     );
 
     if (!echarts) return null;
+
+    // Dispose existing chart instance if it exists to prevent caching issues
+    const existingInstance = echarts.getInstanceByDom(chartContainer);
+    if (existingInstance) {
+        existingInstance.dispose();
+    }
+
     const chartInstance = echarts.init(chartContainer);
     if (!chartInstance) return null;
 

--- a/frontend/src/charts/pointsVsPrice.js
+++ b/frontend/src/charts/pointsVsPrice.js
@@ -126,6 +126,12 @@ export async function renderPointsPriceChart(contentContainer, echarts, position
         return null;
     }
 
+    // Dispose existing chart instance if it exists to prevent caching issues
+    const existingInstance = echarts.getInstanceByDom(chartContainer);
+    if (existingInstance) {
+        existingInstance.dispose();
+    }
+
     const chartInstance = echarts.init(chartContainer);
     if (!chartInstance) {
         console.error('Failed to initialize chart');

--- a/frontend/src/renderDataAnalysis.js
+++ b/frontend/src/renderDataAnalysis.js
@@ -877,7 +877,8 @@ function renderPositionSpecificTableMobile(players, contextColumn = 'total') {
                             <th style="position: sticky; left: 0; background: var(--bg-tertiary); z-index: 11; text-align: left; padding: 0.5rem; min-width: 140px; border-right: 2px solid var(--border-color); box-shadow: 2px 0 4px rgba(0,0,0,0.1);">Player</th>
                             <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Opp</th>
                             <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Status</th>
-                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Pts</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">GW Pts</th>
+                            <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Total</th>
                             <th style="text-align: center; padding: 0.5rem; min-width: 60px;">Form</th>
                             <th style="text-align: center; padding: 0.5rem; min-width: 60px;">${config.header}</th>
                         </tr>
@@ -945,6 +946,10 @@ function renderPositionSpecificTableMobile(players, contextColumn = 'total') {
 
         const isWishlistedPlayer = isWishlisted(player.id);
         const rowBg = getRowHighlightColor(idx, isMyPlayer, isWishlistedPlayer);
+        // For sticky column, use a solid background to prevent overlap issues with gradients
+        const stickyColumnBg = rowBg.startsWith('linear-gradient')
+            ? (isMyPlayer ? 'rgba(56, 189, 248, 0.16)' : (isWishlistedPlayer ? 'rgba(250, 204, 21, 0.18)' : 'var(--bg-secondary)'))
+            : rowBg;
         const rowBorder = borderColor
             ? `border-left: 4px solid ${borderColor};`
             : '';
@@ -958,7 +963,7 @@ function renderPositionSpecificTableMobile(players, contextColumn = 'total') {
                 <td style="
                     position: sticky;
                     left: 0;
-                    background: ${rowBg};
+                    background: ${stickyColumnBg};
                     z-index: 9;
                     padding: 0.5rem;
                     border-right: 2px solid var(--border-color);
@@ -981,6 +986,9 @@ function renderPositionSpecificTableMobile(players, contextColumn = 'total') {
                 </td>
                 <td style="text-align: center; padding: 0.5rem; background: ${ptsStyle.background}; color: ${ptsStyle.color}; font-weight: 700; border-radius: 0.25rem;">
                     ${gwPoints}
+                </td>
+                <td style="text-align: center; padding: 0.5rem; font-weight: 600;">
+                    ${player.total_points}
                 </td>
                 <td style="text-align: center; padding: 0.5rem; background: ${formStyle.background}; color: ${formStyle.color}; font-weight: 600;">
                     ${formatDecimal(player.form)}


### PR DESCRIPTION
Mobile Stats Page:
- Fix sticky column overlap with gradient backgrounds by using solid background colors for sticky column while maintaining visual consistency
- Add Total Points column to all mobile tables for better clarity
- Change GW Pts column header from "Pts" to "GW Pts" to distinguish from total

Transfer Targets:
- Significantly relax filtering criteria to ensure tables populate:
  * Rising Stars: Lower minutes threshold to 15%, form >3.0, FDR ≤3.8
  * Sell Candidates: Lower minutes threshold to 15%, ownership >1%
  * Sort by form first, then transfer momentum for better relevance
- Handle missing github_transfers data gracefully (default to showing players)

Chart Dynamic Scaling:
- Fix chart axis not updating when position filter changes
- Dispose existing chart instances before re-rendering to prevent caching
- Applies to: Minutes Efficiency, Form vs Price, Points vs Price
- Charts now properly recalculate y-axis max based on filtered data