### PR TITLE
Add cohort comparison feature to planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ fplanner/
 - Defensive contribution metrics
 - Differential finder with filters
 
+### Planner Mobile
+- Live comparison against preferred mini-league
+- **Top cohort benchmarks** (10k / 50k / 100k) with per-GW caching
+- Backend endpoint: `GET /api/planner/cohorts?gw=<number>` reuses cached aggregates to avoid repeated heavy computations
+
 ## 🔐 Security
 
 ### Implemented Protections

--- a/backend/routes/plannerRoutes.js
+++ b/backend/routes/plannerRoutes.js
@@ -1,0 +1,40 @@
+// ============================================================================
+// PLANNER ROUTES
+// Provides planner-specific aggregates for mobile planner
+// ============================================================================
+
+import express from 'express';
+import { getCohortMetrics } from '../services/cohortService.js';
+import logger from '../logger.js';
+
+const router = express.Router();
+
+/**
+ * GET /api/planner/cohorts
+ * Returns cached cohort aggregates per gameweek
+ */
+router.get('/api/planner/cohorts', async (req, res) => {
+  const gwParam = req.query.gw;
+  const gameweek = gwParam ? parseInt(gwParam, 10) : undefined;
+
+  if (gwParam && (Number.isNaN(gameweek) || gameweek < 1 || gameweek > 38)) {
+    return res.status(400).json({
+      error: 'Invalid gameweek',
+      message: 'gw must be between 1 and 38'
+    });
+  }
+
+  try {
+    const data = await getCohortMetrics(gameweek);
+    res.json(data);
+  } catch (err) {
+    logger.error(`❌ Failed to load planner cohorts: ${err.message}`);
+    res.status(500).json({
+      error: 'Failed to load planner cohorts',
+      message: err.message
+    });
+  }
+});
+
+export default router;
+

--- a/backend/server.js
+++ b/backend/server.js
@@ -30,6 +30,7 @@ import fplRoutes from './routes/fplRoutes.js';
 import teamRoutes from './routes/teamRoutes.js';
 import leagueRoutes from './routes/leagueRoutes.js';
 import aiRoutes from './routes/aiRoutes.js';
+import plannerRoutes from './routes/plannerRoutes.js';
 
 // Logger
 import logger from './logger.js';
@@ -141,6 +142,9 @@ app.use('/', leagueRoutes);
 
 // AI Routes (/api/ai-insights)
 app.use('/', aiRoutes);
+
+// Planner Routes (/api/planner/*)
+app.use('/', plannerRoutes);
 
 // ============================================================================
 // SERVE FRONTEND IN PRODUCTION

--- a/backend/services/__tests__/cohortService.test.js
+++ b/backend/services/__tests__/cohortService.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { cache } from '../cacheManager.js';
+import * as cohortService from '../cohortService.js';
+
+describe('cohortService caching', () => {
+  beforeEach(() => {
+    cache.cohorts.entries.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cache.cohorts.entries.clear();
+  });
+
+  it('returns cached cohort data when fresh', async () => {
+    const payload = { gameweek: 5, timestamp: Date.now(), buckets: {} };
+    cache.cohorts.entries.set('5', { data: payload, timestamp: payload.timestamp });
+
+    const computeSpy = vi.spyOn(cohortService.executors, 'computeCohorts').mockResolvedValue(payload);
+    const result = await cohortService.getCohortMetrics(5);
+
+    expect(result).toEqual(payload);
+    expect(computeSpy).not.toHaveBeenCalled();
+  });
+
+  it('recomputes cohorts when cache is stale', async () => {
+    const stalePayload = { gameweek: 6, timestamp: Date.now() - (7 * 60 * 60 * 1000), buckets: {} };
+    cache.cohorts.entries.set('6', { data: stalePayload, timestamp: stalePayload.timestamp });
+
+    const freshPayload = { gameweek: 6, timestamp: Date.now(), buckets: { top10k: { sampleSize: 0, averages: {}, distributions: {} } } };
+    const computeSpy = vi.spyOn(cohortService.executors, 'computeCohorts').mockResolvedValue(freshPayload);
+
+    const result = await cohortService.getCohortMetrics(6);
+
+    expect(result).toEqual(freshPayload);
+    expect(computeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('builds sample pages evenly for bucket ranges', () => {
+    const bucket = { key: 'top10k', maxRank: 10000 };
+    const pages = cohortService.__internal.getSamplePagesForBucket(bucket);
+
+    expect(pages[0]).toBe(1);
+    expect(pages[pages.length - 1]).toBeGreaterThanOrEqual(1);
+    expect(pages).toContain(200); // total pages for 10k ranks
+  });
+});
+

--- a/backend/services/cohortService.js
+++ b/backend/services/cohortService.js
@@ -1,0 +1,205 @@
+// ============================================================================
+// COHORT SERVICE
+// Aggregates planner metrics for top cohort buckets
+// ============================================================================
+
+import {
+  fetchBootstrap,
+  fetchFixtures,
+  fetchLeagueStandings,
+  fetchTeamPicks
+} from './fplService.js';
+import {
+  cache,
+  shouldRefreshBootstrap,
+  shouldRefreshFixtures,
+  getCachedCohortMetrics,
+  updateCohortCache
+} from './cacheManager.js';
+import { getLatestFinishedGameweek } from './gameweekUtils.js';
+import { calculateTeamMetricsFromPicks, metricKeys } from './teamMetrics.js';
+import logger from '../logger.js';
+
+const OVERALL_LEAGUE_ID = 314;
+const ENTRIES_PER_PAGE = 50;
+const SAMPLE_PAGES_PER_BUCKET = 8;
+const MAX_TEAMS_PER_BUCKET = 120;
+const MAX_CONCURRENT_FETCHES = 5;
+const COHORT_CACHE_TTL = 6 * 60 * 60 * 1000; // 6 hours
+
+const COHORT_BUCKETS = [
+  { key: 'top10k', label: 'Top 10k', maxRank: 10000 },
+  { key: 'top50k', label: 'Top 50k', maxRank: 50000 },
+  { key: 'top100k', label: 'Top 100k', maxRank: 100000 }
+];
+
+/**
+ * Retrieve cohort metrics for a given gameweek (with cache)
+ * @param {number} [gameweek] - Target gameweek (defaults to latest finished)
+ * @param {Object} [options]
+ * @param {boolean} [options.force=false] - Force recompute even if cache fresh
+ */
+export const executors = {
+  computeCohorts: computeCohortMetrics
+};
+
+export async function getCohortMetrics(gameweek = getLatestFinishedGameweek(), options = {}) {
+  const cached = getCachedCohortMetrics(gameweek);
+  if (!options.force && isCohortDataFresh(cached)) {
+    return cached;
+  }
+
+  const computed = await executors.computeCohorts(gameweek);
+  updateCohortCache(gameweek, computed);
+  return computed;
+}
+
+/**
+ * Compute cohort metrics by sampling ranked teams
+ * Exported for testing
+ * @param {number} gameweek
+ */
+export async function computeCohortMetrics(gameweek) {
+  if (!Number.isInteger(gameweek) || gameweek < 1 || gameweek > 38) {
+    throw new Error('Invalid gameweek supplied to cohort metrics');
+  }
+
+  await ensureBaseData();
+
+  const bucketResults = {};
+  for (const bucket of COHORT_BUCKETS) {
+    const entryIds = await collectEntryIdsForBucket(bucket);
+    const metrics = await fetchMetricsForEntries(entryIds, gameweek);
+    bucketResults[bucket.key] = buildBucketSummary(bucket, metrics, entryIds.length);
+  }
+
+  return {
+    gameweek,
+    timestamp: Date.now(),
+    buckets: bucketResults
+  };
+}
+
+function isCohortDataFresh(data) {
+  if (!data || !data.timestamp) return false;
+  return (Date.now() - data.timestamp) < COHORT_CACHE_TTL;
+}
+
+async function ensureBaseData() {
+  if (!cache.bootstrap.data || shouldRefreshBootstrap()) {
+    await fetchBootstrap();
+  }
+  if (!cache.fixtures.data || shouldRefreshFixtures()) {
+    await fetchFixtures();
+  }
+}
+
+async function collectEntryIdsForBucket(bucket) {
+  const pages = getSamplePagesForBucket(bucket);
+  const entryIds = new Set();
+
+  for (const page of pages) {
+    try {
+      const standings = await fetchLeagueStandings(OVERALL_LEAGUE_ID, page);
+      const results = standings?.standings?.results || [];
+      for (const entry of results) {
+        if (entry.rank && entry.rank <= bucket.maxRank) {
+          entryIds.add(entry.entry);
+          if (entryIds.size >= MAX_TEAMS_PER_BUCKET) {
+            break;
+          }
+        }
+      }
+    } catch (err) {
+      logger.warn(`⚠️ Failed to fetch page ${page} for bucket ${bucket.key}: ${err.message}`);
+    }
+
+    if (entryIds.size >= MAX_TEAMS_PER_BUCKET) {
+      break;
+    }
+  }
+
+  return Array.from(entryIds).slice(0, MAX_TEAMS_PER_BUCKET);
+}
+
+function getSamplePagesForBucket(bucket) {
+  const totalPages = Math.ceil(bucket.maxRank / ENTRIES_PER_PAGE);
+  const step = Math.max(1, Math.floor(totalPages / SAMPLE_PAGES_PER_BUCKET));
+  const pages = new Set([1]);
+
+  for (let page = step; page <= totalPages; page += step) {
+    pages.add(Math.min(page, totalPages));
+  }
+
+  return Array.from(pages).sort((a, b) => a - b);
+}
+
+async function fetchMetricsForEntries(entryIds, gameweek) {
+  const metrics = [];
+
+  let index = 0;
+  async function worker() {
+    while (index < entryIds.length) {
+      const currentIndex = index++;
+      const teamId = entryIds[currentIndex];
+      try {
+        const picks = await fetchTeamPicks(teamId, gameweek);
+        const calculated = calculateTeamMetricsFromPicks(picks?.picks || [], gameweek);
+        if (calculated) {
+          metrics.push(calculated);
+        }
+      } catch (err) {
+        logger.warn(`⚠️ Failed to fetch picks for team ${teamId}: ${err.message}`);
+      }
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(MAX_CONCURRENT_FETCHES, entryIds.length || 1) }, () => worker());
+  await Promise.all(workers);
+
+  return metrics;
+}
+
+function buildBucketSummary(bucket, metrics, attempted) {
+  const distributions = {};
+  const averages = {};
+
+  metricKeys.forEach(key => {
+    distributions[key] = [];
+  });
+
+  metrics.forEach(metric => {
+    metricKeys.forEach(key => {
+      const value = metric[key];
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        distributions[key].push(value);
+      }
+    });
+  });
+
+  metricKeys.forEach(key => {
+    const values = distributions[key];
+    if (values.length === 0) {
+      averages[key] = null;
+      return;
+    }
+    const sum = values.reduce((acc, val) => acc + val, 0);
+    averages[key] = sum / values.length;
+  });
+
+  return {
+    key: bucket.key,
+    label: bucket.label,
+    maxRank: bucket.maxRank,
+    sampleSize: metrics.length,
+    attempted,
+    averages,
+    distributions
+  };
+}
+
+export const __internal = {
+  getSamplePagesForBucket,
+  isCohortDataFresh
+};
+

--- a/backend/services/teamMetrics.js
+++ b/backend/services/teamMetrics.js
@@ -1,0 +1,124 @@
+// ============================================================================
+// TEAM METRICS SERVICE
+// Server-side replica of planner metrics used for cohort aggregation
+// ============================================================================
+
+import { cache } from './cacheManager.js';
+
+const DEFAULT_FIXTURE_DIFFICULTY = 3;
+const METRIC_KEYS = ['avgPPM', 'avgFDR', 'avgForm', 'expectedPoints', 'avgOwnership', 'avgXGI'];
+
+/**
+ * Calculate planner metrics for a given squad
+ * @param {Array} picks - Team picks array from FPL API
+ * @param {number} gameweek - Target gameweek
+ * @returns {Object} Team metrics
+ */
+export function calculateTeamMetricsFromPicks(picks, gameweek) {
+  if (!Array.isArray(picks) || picks.length === 0) {
+    return getEmptyMetrics();
+  }
+
+  const players = picks
+    .map(pick => getPlayerById(pick.element))
+    .filter(Boolean);
+
+  if (!players.length) {
+    return getEmptyMetrics();
+  }
+
+  const squadStats = calculateSquadAverages(players, gameweek);
+  const avgForm = calculateAverage(players, player => parseFloat(player.form) || 0);
+  const avgXGI = calculateAverage(players, player => parseFloat(player.expected_goal_involvements_per_90) || 0);
+  const expectedPoints = players.reduce((sum, player) => {
+    const epNext = parseFloat(player.ep_next) || 0;
+    return sum + (epNext * 5);
+  }, 0);
+
+  return {
+    avgPPM: squadStats.avgPPM,
+    avgFDR: squadStats.avgFDR,
+    avgForm,
+    expectedPoints,
+    avgOwnership: squadStats.avgOwnership,
+    avgMinPercent: squadStats.avgMinPercent,
+    avgXGI
+  };
+}
+
+/**
+ * Calculate squad averages for planner metrics
+ * @param {Array} players - Player objects from bootstrap
+ * @param {number} gameweek - Target gameweek
+ * @returns {Object} Aggregate stats
+ */
+function calculateSquadAverages(players, gameweek) {
+  const totals = players.reduce((acc, player) => {
+    acc.ppm += calculatePPM(player);
+    acc.ownership += parseFloat(player.selected_by_percent) || 0;
+    acc.minutesPercent += calculateMinutesPercentage(player, gameweek);
+    acc.fdr += calculateFixtureDifficulty(player.team, 5, gameweek + 1);
+    return acc;
+  }, { ppm: 0, ownership: 0, minutesPercent: 0, fdr: 0 });
+
+  const count = players.length;
+
+  return {
+    avgPPM: count ? totals.ppm / count : 0,
+    avgOwnership: count ? totals.ownership / count : 0,
+    avgMinPercent: count ? totals.minutesPercent / count : 0,
+    avgFDR: count ? totals.fdr / count : DEFAULT_FIXTURE_DIFFICULTY
+  };
+}
+
+function calculateAverage(players, getter) {
+  if (!players.length) return 0;
+  const total = players.reduce((sum, player) => sum + getter(player), 0);
+  return total / players.length;
+}
+
+function calculatePPM(player) {
+  if (!player || !player.now_cost) return 0;
+  return (player.total_points || 0) / (player.now_cost / 10);
+}
+
+function calculateMinutesPercentage(player, gameweek) {
+  if (!player || !gameweek) return 0;
+  return ((player.minutes || 0) / (gameweek * 90)) * 100;
+}
+
+function calculateFixtureDifficulty(teamId, count = 5, startGameweek = 1) {
+  if (!teamId || !cache.fixtures?.data?.length) {
+    return DEFAULT_FIXTURE_DIFFICULTY;
+  }
+
+  const fixtures = cache.fixtures.data
+    .filter(f => (f.team_h === teamId || f.team_a === teamId) && f.event >= startGameweek)
+    .sort((a, b) => a.event - b.event)
+    .slice(0, count);
+
+  if (!fixtures.length) {
+    return DEFAULT_FIXTURE_DIFFICULTY;
+  }
+
+  const totalDifficulty = fixtures.reduce((sum, fixture) => {
+    const isHome = fixture.team_h === teamId;
+    return sum + (isHome ? fixture.team_h_difficulty : fixture.team_a_difficulty || DEFAULT_FIXTURE_DIFFICULTY);
+  }, 0);
+
+  return totalDifficulty / fixtures.length;
+}
+
+function getPlayerById(playerId) {
+  return cache.bootstrap?.data?.elements?.find(element => element.id === playerId) || null;
+}
+
+function getEmptyMetrics() {
+  return METRIC_KEYS.reduce((acc, key) => {
+    acc[key] = 0;
+    return acc;
+  }, { avgMinPercent: 0 });
+}
+
+export const metricKeys = METRIC_KEYS;
+

--- a/frontend/src/data.js
+++ b/frontend/src/data.js
@@ -55,6 +55,8 @@ let playersCacheKey = null;
 /** Team data cache (teamId -> { data, timestamp }) */
 const teamCache = new Map();
 const TEAM_CACHE_TTL = 2 * 60 * 1000; // 2 minutes
+const plannerCohortCache = new Map();
+const COHORT_CACHE_TTL = 2 * 60 * 60 * 1000; // 2 hours
 
 /** Auto-refresh interval in milliseconds (2 minutes) */
 const AUTO_REFRESH_INTERVAL = 2 * 60 * 1000;
@@ -489,6 +491,43 @@ export function invalidateTeamCache(teamId) {
     } else {
         teamCache.clear();
     }
+}
+
+function getPlannerCohortCache(gameweek) {
+    const cached = plannerCohortCache.get(String(gameweek));
+    if (!cached) return null;
+    if ((Date.now() - cached.timestamp) > COHORT_CACHE_TTL) {
+        plannerCohortCache.delete(String(gameweek));
+        return null;
+    }
+    return cached.data;
+}
+
+function setPlannerCohortCache(gameweek, data) {
+    plannerCohortCache.set(String(gameweek), {
+        data,
+        timestamp: Date.now()
+    });
+}
+
+export async function loadPlannerCohorts(gameweek) {
+    if (!gameweek) {
+        throw new Error('Gameweek is required for cohort comparisons');
+    }
+
+    const cached = getPlannerCohortCache(gameweek);
+    if (cached) {
+        return cached;
+    }
+
+    const response = await fetch(`${API_BASE}/planner/cohorts?gw=${gameweek}`);
+    if (!response.ok) {
+        throw new Error('Failed to load planner cohort data');
+    }
+
+    const data = await response.json();
+    setPlannerCohortCache(gameweek, data);
+    return data;
 }
 
 export async function loadMyTeam(teamId, options = {}) {

--- a/frontend/src/sharedState.js
+++ b/frontend/src/sharedState.js
@@ -17,6 +17,7 @@ export const sharedState = {
     leagueMetricsCache: new Map(), // key(leagueId+gw) -> aggregated metrics
     rivalTeamCache: new Map(), // entryId -> team data
     captainCache: new Map(), // entryId -> captain name
+    cohortMetricsCache: new Map(), // gameweek -> cohort aggregates
 
     // My team data
     myTeamData: null,
@@ -31,6 +32,7 @@ export const sharedState = {
         this.leagueMetricsCache.clear();
         this.rivalTeamCache.clear();
         this.captainCache.clear();
+        this.cohortMetricsCache.clear();
         this.myTeamData = null;
     },
 


### PR DESCRIPTION
- Introduced new backend endpoint for fetching cohort metrics.
- Implemented caching for cohort data in both backend and frontend.
- Updated frontend to display cohort comparison metrics alongside league metrics.
- Enhanced README with details about the new planner mobile features and cohort benchmarks.
- Added utility functions for managing cohort cache in the frontend and backend.