### PR TITLE
Fix form color-coding to include values from 0 onwards

### DIFF
--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -171,8 +171,8 @@ export function getPtsHeatmap(points, metric = 'pts') {
         if (points >= 7) return 'heat-dark-green';
         if (points >= 5) return 'heat-light-green';
         if (points >= 3) return 'heat-yellow';
-        if (points >= 1) return 'heat-red';
-        return 'heat-gray';
+        if (points >= 0) return 'heat-red'; // Include all forms from 0 onwards as red (poor)
+        return 'heat-gray'; // Only for negative/invalid values
     }
 
     if (metric === 'value') {


### PR DESCRIPTION
Changed form heatmap threshold from >= 1 to >= 0 so that all forms from 0 onwards are color-coded with red (poor form color) instead of gray.

Changes:
- Updated getPtsHeatmap() in utils.js
- Form values 0.0 to 0.9 now show as red (poor) instead of gray
- Consistent with gameweek points heatmap which also uses >= 0

Form color scale:
- >= 7: Dark green (excellent)
- >= 5: Light green (good)
- >= 3: Yellow (average)
- >= 0: Red (poor) ← Now includes 0.0-0.9
- < 0: Gray (invalid only)