### PR TITLE
Fix match status not updating from LIVE to FT by implementing dynamic…

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -74,7 +74,8 @@ export function getGithubUrls(currentGW, isFinished) {
 // ============================================================================
 
 export const TTL = {
-  FIXTURES: 12 * 60 * 60 * 1000,      // 12 hours (rarely changes)
+  FIXTURES_LIVE: 2 * 60 * 1000,       // 2 minutes (during live GW - need frequent updates for match status)
+  FIXTURES_FINISHED: 12 * 60 * 60 * 1000,  // 12 hours (when GW finished - rarely changes)
   GW_LIVE: 30 * 60 * 1000,            // 30 minutes (during live GW)
   GW_FINISHED: 12 * 60 * 60 * 1000,   // 12 hours (GW finished)
   GITHUB_CHECK_INTERVAL: 5 * 60 * 1000 // Check GitHub era every 5 min

--- a/frontend/src/data.js
+++ b/frontend/src/data.js
@@ -402,8 +402,21 @@ export function startAutoRefresh(onRefresh = null) {
                 return; // Skip this cycle
             }
 
-            console.log('🔄 Auto-refreshing enriched bootstrap...');
+            console.log('🔄 Auto-refreshing enriched bootstrap and fixtures...');
+
+            // Refresh enriched bootstrap (with live stats)
             await loadEnrichedBootstrap();
+
+            // Also refresh fixtures to catch match status changes (started/finished flags)
+            // Backend uses dynamic TTL: 2 min during live GW, 12 hours when finished
+            const fixturesResponse = await fetch(`${API_BASE}/fpl-data`);
+            if (fixturesResponse.ok) {
+                const data = await fixturesResponse.json();
+                if (data.fixtures) {
+                    fplFixtures = data.fixtures;
+                    console.log('✅ Fixtures refreshed');
+                }
+            }
 
             if (onDataRefreshCallback) {
                 onDataRefreshCallback();


### PR DESCRIPTION
… fixtures cache TTL

**Problem:**
- Matches would show "LIVE (90)" even after finishing because fixture.finished flag wasn't being updated
- Fixtures were cached for 12 hours, so match status changes weren't detected during live gameweeks
- Auto-refresh only updated player stats, not fixture data

**Root Cause:**
- FPL API updates fixture.finished flag in real-time when matches end
- Our app cached fixtures for 12 hours (TTL.FIXTURES)
- Auto-refresh called /api/bootstrap/enriched (no fixtures) but not /api/fpl-data (includes fixtures)
- Status logic checked stale fixture.finished flag, always showing LIVE

**Solution (Option A - Dynamic Fixtures TTL):**
1. Backend config: Split TTL.FIXTURES into:
   - TTL.FIXTURES_LIVE: 2 minutes (during live GW)
   - TTL.FIXTURES_FINISHED: 12 hours (when GW finished)

2. Cache manager: Added getFixturesCacheTTL() to return appropriate TTL based on GW status
   - Updated shouldRefreshFixtures() to use dynamic TTL
   - Better logging showing seconds during live GW, hours when finished

3. Frontend auto-refresh: Now fetches both:
   - /api/bootstrap/enriched (player live stats)
   - /api/fpl-data (fixtures with match status)

**Impact:**
- During live GW: Fixtures refresh every 2 minutes (same as player stats)
- Match status transitions from LIVE to FT within 2 minutes of match ending
- When GW finished: Fixtures still cached for 12 hours (no unnecessary requests)
- Smart caching: Backend only fetches from FPL API when TTL expires

Files changed:
- backend/config.js: Dynamic TTL constants
- backend/services/cacheManager.js: Dynamic TTL logic + improved logging
- frontend/src/data.js: Auto-refresh now includes fixtures