### PR TITLE
Simplify player row Line 3 to show FPL news directly instead of risk …

### DIFF
--- a/frontend/src/myTeam/compact/compactPlayerRow.js
+++ b/frontend/src/myTeam/compact/compactPlayerRow.js
@@ -14,7 +14,6 @@ import {
     getPositionShort
 } from '../../utils.js';
 import { getGWOpponent, getMatchStatus } from '../../fixtures.js';
-import { analyzePlayerRisks, renderRiskTooltip } from '../../risk.js';
 import {
     renderOpponentBadge,
     calculateStatusColor,
@@ -46,8 +45,6 @@ export function renderCompactPlayerRow(pick, player, gwNumber) {
     const badgeMarkup = badges.length > 0 ? ` <span style="font-size: 0.65rem;">${badges.join(' ')}</span>` : '';
 
     const gwOpp = getGWOpponent(player.team, gwNumber);
-    const risks = analyzePlayerRisks(player);
-    const riskTooltip = renderRiskTooltip(risks);
 
     // Get match status display with color coding
     const matchStatus = getMatchStatus(player.team, gwNumber, player);
@@ -77,31 +74,32 @@ export function renderCompactPlayerRow(pick, player, gwNumber) {
     // Add thick border after row 11 (last starter)
     const borderStyle = pick.position === 11 ? '3px solid var(--border-color)' : '1px solid var(--border-color)';
 
-    // Colored left border for players with news/injury
+    // Display FPL news with colored left border based on severity
     let leftBorderStyle = 'none';
     let riskContextMessage = '';
     let riskContextColor = '';
 
     if (player.news && player.news.trim() !== '') {
+        // Use FPL news directly (e.g., "Suspended until 06 Dec", "Hamstring injury")
+        riskContextMessage = player.news;
+
+        // Color based on chance of playing severity
         const chanceOfPlaying = player.chance_of_playing_next_round;
         if (chanceOfPlaying !== null && chanceOfPlaying !== undefined) {
             if (chanceOfPlaying <= 25) {
-                leftBorderStyle = '3px solid #ef4444'; // Red
+                leftBorderStyle = '3px solid #ef4444'; // Red - very unlikely to play
                 riskContextColor = '#ef4444';
-                riskContextMessage = `${chanceOfPlaying}% chance: ${player.news}`;
             } else if (chanceOfPlaying <= 50) {
-                leftBorderStyle = '3px solid #f97316'; // Orange
+                leftBorderStyle = '3px solid #f97316'; // Orange - doubtful
                 riskContextColor = '#f97316';
-                riskContextMessage = `${chanceOfPlaying}% chance: ${player.news}`;
             } else {
-                leftBorderStyle = '3px solid #fbbf24'; // Yellow
+                leftBorderStyle = '3px solid #fbbf24'; // Yellow - possible
                 riskContextColor = '#fbbf24';
-                riskContextMessage = `${chanceOfPlaying}% chance: ${player.news}`;
             }
         } else {
-            leftBorderStyle = '3px solid #fbbf24'; // Yellow default for news
+            // No percentage data - default to yellow
+            leftBorderStyle = '3px solid #fbbf24';
             riskContextColor = '#fbbf24';
-            riskContextMessage = player.news;
         }
     }
 

--- a/frontend/src/renderDataAnalysis.js
+++ b/frontend/src/renderDataAnalysis.js
@@ -41,8 +41,6 @@ import {
     attachRiskTooltipListeners
 } from './renderHelpers.js';
 
-import { analyzePlayerRisks } from './risk.js';
-
 import { debounce } from './utils/debounce.js';
 
 import {
@@ -868,18 +866,27 @@ function renderPositionSpecificTableMobile(players, contextColumn = 'total') {
         const matchStatus = getMatchStatus(player.team, currentGW, player);
         const isMyPlayer = Boolean(player.__isMine || myPlayerIds.has(player.id));
 
-        // Risk analysis
-        const risks = analyzePlayerRisks(player);
-
-        // Determine border color based on risk severity
-        const hasHighRisk = risks.some(r => r.severity === 'high');
-        const hasMediumRisk = risks.some(r => r.severity === 'medium');
-        const hasLowRisk = risks.length > 0;
-
+        // Use FPL news for Line 3 display
+        let newsMessage = '';
         let borderColor = '';
-        if (hasHighRisk) borderColor = 'var(--danger-color)';
-        else if (hasMediumRisk) borderColor = 'var(--warning-color)';
-        else if (hasLowRisk) borderColor = '#eab308';
+
+        if (player.news && player.news.trim() !== '') {
+            newsMessage = player.news;
+
+            // Color based on chance of playing severity
+            const chanceOfPlaying = player.chance_of_playing_next_round;
+            if (chanceOfPlaying !== null && chanceOfPlaying !== undefined) {
+                if (chanceOfPlaying <= 25) {
+                    borderColor = '#ef4444'; // Red - very unlikely to play
+                } else if (chanceOfPlaying <= 50) {
+                    borderColor = '#f97316'; // Orange - doubtful
+                } else {
+                    borderColor = '#fbbf24'; // Yellow - possible
+                }
+            } else {
+                borderColor = '#fbbf24'; // Yellow default
+            }
+        }
 
         // Points (GW points)
         const gwPoints = player.event_points || 0;
@@ -960,8 +967,8 @@ function renderPositionSpecificTableMobile(players, contextColumn = 'total') {
                         <div style="font-size: 0.6rem; color: var(--text-secondary); white-space: nowrap;">
                             ${getTeamShortName(player.team)} • ${formatCurrency(player.now_cost)} • ${(parseFloat(player.selected_by_percent) || 0).toFixed(1)}% • <span style="display: inline-block; padding: 0.2rem 0.4rem; border-radius: 3px; font-weight: 600; font-size: 0.65rem; background: ${formStyle.background}; color: ${formStyle.color};">${formatDecimal(player.form)}</span>
                         </div>
-                        <!-- Line 3: Risk context (if any) -->
-                        ${risks.length > 0 ? `<div style="font-size: 0.6rem; color: ${borderColor}; line-height: 1.2; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${escapeHtml(risks[0]?.message || 'Issue')}</div>` : `<div style="height: 0.8rem;"></div>`}
+                        <!-- Line 3: FPL News (if any) -->
+                        ${newsMessage ? `<div style="font-size: 0.6rem; color: ${borderColor}; line-height: 1.2; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${escapeHtml(newsMessage)}</div>` : `<div style="height: 0.8rem;"></div>`}
                     </div>
                 </td>
                 <td style="text-align: center; padding: 0.5rem;">


### PR DESCRIPTION
…analyzer

Removed custom risk analyzer logic from player row Line 3 display and now show FPL news directly for clearer, more informative injury/suspension information.

Changes:
- compactPlayerRow.js: Use player.news directly instead of risk analyzer message
- renderDataAnalysis.js: Same change for Data Analysis mobile table

Before: "0% fit" or "0% chance: Suspended until 06 Dec"
After: "Suspended until 06 Dec" (direct from FPL)

Benefits:
- More informative: "Suspended until 06 Dec" vs "0% fit"
- No redundancy: Don't duplicate work FPL already does
- Simpler code: Less logic to maintain
- Consistent with FPL official data

Color coding preserved:
- Red (chance ≤ 25%): Very unlikely to play
- Orange (chance ≤ 50%): Doubtful
- Yellow (chance > 50% or no percentage): Possible

Note: Risk analyzer (rotation risk, yellow card warnings, etc.) can still be used for advanced tooltips/filtering in future, but Line 3 now shows clean FPL news.