### PR TITLE
Add centered logo to mobile header with circular rendering

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,9 +16,13 @@
         <nav style="background: var(--bg-secondary); color: white; padding: 1rem 2rem; box-shadow: 0 2px 8px var(--shadow);">
             <div style="max-width: 1400px; margin: 0 auto; display: flex; justify-content: space-between; align-items: center;">
                 <div style="display: flex; align-items: center; gap: 2rem;">
-                    <h1 style="font-size: 1.5rem; font-weight: 700; margin: 0; letter-spacing: -0.02em;">
-                        FPLanner
-                    </h1>
+                    <!-- Logo/Brand -->
+                    <div id="nav-brand" style="display: flex; align-items: center;">
+                        <h1 style="font-size: 1.5rem; font-weight: 700; margin: 0; letter-spacing: -0.02em;">
+                            FPLanner
+                        </h1>
+                        <img id="logo-image" src="/logo.png" alt="FPLanner Logo" style="display: none; width: 40px; height: 40px; border-radius: 50%; object-fit: cover;">
+                    </div>
                     <div id="nav-links" style="display: flex; gap: 1rem;">
                         <!-- Navigation links will be inserted here -->
                     </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -377,6 +377,35 @@ body {
     font-size: 1.25rem !important;
   }
 
+  /* Mobile header layout: left space for future widget, centered logo */
+  nav > div {
+    justify-content: center !important;
+    position: relative;
+  }
+
+  nav > div > div:first-child {
+    position: absolute;
+    left: 0;
+  }
+
+  nav > div > div:last-child {
+    position: absolute;
+    right: 0;
+  }
+
+  /* Show logo image on mobile, hide text */
+  #nav-brand h1 {
+    display: none !important;
+  }
+
+  #nav-brand img {
+    display: block !important;
+    width: 48px !important;
+    height: 48px !important;
+    border-radius: 50% !important;
+    object-fit: cover !important;
+  }
+
 
   /* Hide full countdown text on very small screens */
   @media (max-width: 380px) {


### PR DESCRIPTION
Replace text-based header with logo image on mobile devices. The logo is centered in the header with space reserved on the left for future widget placement. Desktop view maintains the text-based header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)