### PR TITLE
Fix logo white space borders with overflow crop technique

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -403,6 +403,10 @@ body {
     left: 50% !important;
     transform: translateX(-50%) !important;
     z-index: 1;
+    overflow: hidden !important;
+    border-radius: 50% !important;
+    width: 40px !important;
+    height: 40px !important;
   }
 
   /* Show logo image on mobile, hide text */
@@ -412,13 +416,14 @@ body {
 
   #nav-brand img {
     display: block !important;
-    width: 40px !important;
-    height: 40px !important;
+    /* Make image larger than container to crop borders */
+    width: 60px !important;
+    height: 60px !important;
+    /* Position it centered within the 40px circular container */
+    margin: -10px !important;
     border-radius: 50% !important;
     object-fit: cover !important;
     object-position: center !important;
-    /* Crop more aggressively to remove white space */
-    transform: scale(1.3) !important;
   }
 
 


### PR DESCRIPTION
- Apply overflow hidden and fixed dimensions to logo container
- Make logo image 60px within 40px container using negative margins
- This crops out ~10px from all sides, removing white space borders
- Remove transform scale approach in favor of true overflow crop

🤖 Generated with [Claude Code](https://claude.com/claude-code)