### PR TITLE
Remove conflicting inline styles to fix logo display

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,11 +17,11 @@
             <div style="max-width: 1400px; margin: 0 auto; display: flex; justify-content: space-between; align-items: center;">
                 <div style="display: flex; align-items: center; gap: 2rem;">
                     <!-- Logo/Brand -->
-                    <div id="nav-brand" style="display: flex; align-items: center;">
+                    <div id="nav-brand">
                         <h1 style="font-size: 1.5rem; font-weight: 700; margin: 0; letter-spacing: -0.02em;">
                             FPLanner
                         </h1>
-                        <img id="logo-image" src="/logo.png" alt="FPLanner Logo" style="display: none; width: 40px; height: 40px; border-radius: 50%; object-fit: cover;">
+                        <img id="logo-image" src="/logo.png" alt="FPLanner Logo" style="display: none;">
                     </div>
                     <div id="nav-links" style="display: flex; gap: 1rem;">
                         <!-- Navigation links will be inserted here -->

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -335,6 +335,16 @@ body {
   }
 }
 
+/* Base nav-brand styles for desktop */
+#nav-brand {
+  display: flex;
+  align-items: center;
+}
+
+#nav-brand img {
+  display: none;
+}
+
 /* Mobile navigation styles */
 @media (max-width: 767px) {
   /* Stack navigation vertically on mobile */


### PR DESCRIPTION
- Remove inline styles from #nav-brand that conflicted with CSS
- Remove inline sizing from logo image
- Add base desktop styles for #nav-brand
- Mobile CSS can now properly override and display circular logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)