### PR TITLE
Add mobile team info widget and update navigation logic

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,6 +16,8 @@
         <nav style="background: var(--bg-secondary); color: white; padding: 1rem 2rem; box-shadow: 0 2px 8px var(--shadow);">
             <div style="max-width: 1400px; margin: 0 auto; display: flex; justify-content: space-between; align-items: center;">
                 <div style="display: flex; align-items: center; gap: 2rem;">
+                    <!-- Team Info Widget (mobile only) -->
+                    <div id="nav-team-widget" style="display: none;"></div>
                     <!-- Logo/Brand -->
                     <div id="nav-brand">
                         <h1 style="font-size: 1.5rem; font-weight: 700; margin: 0; letter-spacing: -0.02em;">

--- a/frontend/src/renderMyTeam.js
+++ b/frontend/src/renderMyTeam.js
@@ -479,6 +479,11 @@ export function renderMyTeam(teamData, subTab = 'overview') {
     myTeamState.currentTab = subTab;
     sharedState.updateTeamData(teamData);
 
+    // Update nav team widget
+    if (window.updateNavTeamWidget) {
+        window.updateNavTeamWidget(teamData);
+    }
+
     // Setup auto-refresh for live GW
     setupTeamAutoRefresh();
 

--- a/frontend/src/sharedState.js
+++ b/frontend/src/sharedState.js
@@ -79,5 +79,10 @@ export const sharedState = {
         } catch (err) {
             console.warn('Failed to cache team data for reuse', err);
         }
+
+        // Update nav team widget if available
+        if (typeof window !== 'undefined' && window.updateNavTeamWidget) {
+            window.updateNavTeamWidget(teamData);
+        }
     }
 };

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -399,6 +399,14 @@ body {
     flex: 1;
     display: flex;
     justify-content: flex-start;
+    align-items: center;
+  }
+
+  /* Team widget styling */
+  #nav-team-widget {
+    display: flex !important;
+    align-items: center;
+    z-index: 2;
   }
 
   nav > div > div:last-child {


### PR DESCRIPTION
- Introduced a mobile-only team info widget in the navigation bar.
- Enhanced `main.js` to expose `updateNavTeamWidget` globally and handle window resize events for dynamic updates.
- Implemented logic to calculate and display team statistics, including points and rankings, in the widget.
- Updated `renderMyTeam` and `sharedState` to ensure the widget reflects the latest team data.
- Added CSS styles for the new widget to ensure proper alignment and visibility.