### PR TITLE
Refactor team info display and enhance ranking features

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,12 +23,12 @@
                         </h1>
                         <img id="logo-image" src="/logo.png" alt="FPLanner Logo" style="display: none;">
                     </div>
-                    <!-- Team Info (mobile only) -->
+                    <!-- Team Info Widget (mobile only) -->
+                    <div id="nav-team-widget" style="display: none;"></div>
+                    <!-- Team Info (mobile only) - deprecated -->
                     <div id="nav-team-info" style="display: none; align-items: center; gap: 0.5rem; flex: 1;">
                         <!-- Will be populated by JavaScript -->
                     </div>
-                    <!-- Team Info Widget (mobile only) - deprecated, keeping for backwards compatibility -->
-                    <div id="nav-team-widget" style="display: none;"></div>
                     <div id="nav-links" style="display: flex; gap: 1rem;">
                         <!-- Navigation links will be inserted here -->
                     </div>

--- a/frontend/src/myTeam/managerModal.js
+++ b/frontend/src/myTeam/managerModal.js
@@ -1,0 +1,236 @@
+// ============================================================================
+// MANAGER MODAL
+// Modal for team management (switch team, future: team history, settings)
+// ============================================================================
+
+import { escapeHtml } from '../utils.js';
+import { getGlassmorphism, getShadow, getMobileBorderRadius, getAnimationCurve, getAnimationDuration } from '../styles/mobileDesignSystem.js';
+
+/**
+ * Check if dark mode is active
+ * @returns {boolean} True if dark mode is active
+ */
+function isDarkMode() {
+    return document.documentElement.getAttribute('data-theme') === 'dark';
+}
+
+/**
+ * Inject modal animation keyframes
+ */
+function injectModalAnimations() {
+    if (document.getElementById('manager-modal-animations')) return;
+
+    const style = document.createElement('style');
+    style.id = 'manager-modal-animations';
+    style.textContent = `
+        @keyframes fadeIn {
+            from { opacity: 0; }
+            to { opacity: 1; }
+        }
+        @keyframes fadeOut {
+            from { opacity: 1; }
+            to { opacity: 0; }
+        }
+        @keyframes slideUp {
+            from { 
+                opacity: 0;
+                transform: translateY(20px);
+            }
+            to { 
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+        @keyframes slideDown {
+            from { 
+                opacity: 1;
+                transform: translateY(0);
+            }
+            to { 
+                opacity: 0;
+                transform: translateY(20px);
+            }
+        }
+    `;
+    document.head.appendChild(style);
+}
+
+/**
+ * Show Manager Modal
+ * @param {Object} teamData - Current team data (optional)
+ */
+export function showManagerModal(teamData = null) {
+    injectModalAnimations();
+
+    // Remove existing modal
+    const existingModal = document.getElementById('manager-modal');
+    if (existingModal) {
+        existingModal.remove();
+    }
+
+    const isDark = isDarkMode();
+    const glassEffect = getGlassmorphism(isDark, 'heavy');
+    const shadow = getShadow('modal');
+    const radius = getMobileBorderRadius('xlarge');
+    const animationCurve = getAnimationCurve('decelerate');
+    const animationDuration = getAnimationDuration('modal');
+
+    // Get team info if available
+    let teamName = 'My Team';
+    if (teamData && teamData.team) {
+        teamName = teamData.team.name || 'My Team';
+    }
+
+    const modalHTML = `
+        <div id="manager-modal" style="
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0,0,0,0.4);
+            backdrop-filter: blur(20px) saturate(180%);
+            -webkit-backdrop-filter: blur(20px) saturate(180%);
+            z-index: 10000;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 1rem;
+            animation: fadeIn ${animationDuration} ${animationCurve};
+        ">
+            <div style="
+                backdrop-filter: ${glassEffect.backdropFilter};
+                -webkit-backdrop-filter: ${glassEffect.WebkitBackdropFilter};
+                background: ${glassEffect.background};
+                border: ${glassEffect.border};
+                border-radius: ${radius};
+                max-width: 400px;
+                width: 100%;
+                max-height: 85vh;
+                overflow-y: auto;
+                box-shadow: ${shadow};
+                animation: slideUp ${animationDuration} ${animationCurve};
+            ">
+                <!-- Header -->
+                <div style="
+                    padding: 0.75rem 1rem;
+                    border-bottom: ${glassEffect.border};
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: center;
+                ">
+                    <div style="font-size: 0.9rem; font-weight: 600; color: var(--text-primary);">
+                        ${escapeHtml(teamName)}
+                    </div>
+                    <button
+                        id="close-manager-modal"
+                        style="
+                            background: transparent;
+                            border: none;
+                            font-size: 1.5rem;
+                            color: var(--text-secondary);
+                            cursor: pointer;
+                            padding: 0;
+                            width: 2rem;
+                            height: 2rem;
+                            display: flex;
+                            align-items: center;
+                            justify-content: center;
+                        "
+                    >
+                        ×
+                    </button>
+                </div>
+                
+                <!-- Content -->
+                <div style="padding: 1rem;">
+                    <button
+                        id="manager-switch-team-btn"
+                        style="
+                            width: 100%;
+                            padding: 0.75rem 1rem;
+                            background: var(--primary-color);
+                            color: white;
+                            border: none;
+                            border-radius: ${radius};
+                            font-size: 0.85rem;
+                            font-weight: 600;
+                            cursor: pointer;
+                            transition: all ${animationDuration} ${animationCurve};
+                            display: flex;
+                            align-items: center;
+                            justify-content: center;
+                            gap: 0.5rem;
+                        "
+                    >
+                        <i class="fas fa-exchange-alt"></i>
+                        Switch Team
+                    </button>
+                </div>
+            </div>
+        </div>
+    `;
+
+    document.body.insertAdjacentHTML('beforeend', modalHTML);
+    attachManagerModalListeners();
+}
+
+/**
+ * Attach event listeners to Manager Modal
+ */
+function attachManagerModalListeners() {
+    const modal = document.getElementById('manager-modal');
+    if (!modal) return;
+
+    // Close button
+    const closeBtn = document.getElementById('close-manager-modal');
+    if (closeBtn) {
+        closeBtn.addEventListener('click', closeManagerModal);
+    }
+
+    // Switch Team button
+    const switchTeamBtn = document.getElementById('manager-switch-team-btn');
+    if (switchTeamBtn) {
+        switchTeamBtn.addEventListener('click', () => {
+            closeManagerModal();
+            if (window.resetMyTeam) {
+                window.resetMyTeam();
+            }
+        });
+    }
+
+    // Close on backdrop click
+    modal.addEventListener('click', (e) => {
+        if (e.target.id === 'manager-modal') {
+            closeManagerModal();
+        }
+    });
+}
+
+/**
+ * Close Manager Modal with animation
+ */
+export function closeManagerModal() {
+    const modal = document.getElementById('manager-modal');
+    if (!modal) return;
+
+    const animationCurve = getAnimationCurve('accelerate');
+    const animationDuration = getAnimationDuration('modal');
+
+    modal.style.animation = `fadeOut ${animationDuration} ${animationCurve}`;
+    const content = modal.querySelector('div');
+    if (content) {
+        content.style.animation = `slideDown ${animationDuration} ${animationCurve}`;
+    }
+
+    setTimeout(() => {
+        modal.remove();
+    }, parseFloat(animationDuration));
+}
+
+// Expose globally
+if (typeof window !== 'undefined') {
+    window.showManagerModal = showManagerModal;
+    window.closeManagerModal = closeManagerModal;
+}
+

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -412,20 +412,23 @@ body {
     display: flex;
     justify-content: flex-start;
     align-items: center;
+    gap: 0.75rem;
     padding-right: 0.75rem;
     min-width: 0;
   }
 
-  /* Team widget styling - deprecated, hide it */
+  /* Team widget styling - show on mobile */
   #nav-team-widget {
-    display: none !important;
-  }
-
-  /* Team info (new) - show on mobile */
-  #nav-team-info {
     display: flex !important;
     align-items: center;
     z-index: 2;
+    flex: 1;
+    justify-content: flex-start;
+  }
+
+  /* Team info (deprecated) - hide it */
+  #nav-team-info {
+    display: none !important;
   }
 
   /* Ensure countdown has proper height */

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -121,6 +121,31 @@ export function formatDecimal(value) {
 }
 
 /**
+ * Format rank number to compact format (479k, 3.9M)
+ * @param {number} rank - Rank number
+ * @returns {string} Formatted rank string
+ * @example
+ * formatRank(479343) // Returns '479k'
+ * formatRank(3955171) // Returns '3.9M'
+ * formatRank(123) // Returns '123'
+ */
+export function formatRank(rank) {
+    if (!rank || rank === 0 || isNaN(rank)) return 'N/A';
+    
+    if (rank >= 1000000) {
+        // Format as millions (e.g., 3.9M)
+        const millions = rank / 1000000;
+        return millions % 1 === 0 ? `${millions}M` : `${millions.toFixed(1)}M`;
+    } else if (rank >= 1000) {
+        // Format as thousands (e.g., 479k)
+        const thousands = rank / 1000;
+        return thousands % 1 === 0 ? `${thousands}k` : `${thousands.toFixed(0)}k`;
+    }
+    
+    return rank.toString();
+}
+
+/**
  * Format minutes played
  * @param {number} minutes - Total minutes
  * @param {number} gw - Current gameweek (optional)


### PR DESCRIPTION
- Updated the mobile team info section to use a new widget, replacing the deprecated team info display.
- Added functionality to format and display overall and gameweek ranks in the new widget.
- Improved sorting logic for fixtures based on their state (upcoming, live, finished, postponed).
- Introduced a new utility function to format rank numbers into a compact format (e.g., 479k, 3.9M).
- Adjusted CSS styles to reflect the changes in the team widget and info display.