### PR TITLE
Add agent logging to match status and team auto-refresh processes

### DIFF
--- a/frontend/src/data.js
+++ b/frontend/src/data.js
@@ -411,6 +411,11 @@ export function startAutoRefresh(onRefresh = null) {
             if (fixturesResponse.ok) {
                 const data = await fixturesResponse.json();
                 if (data.fixtures) {
+                    // #region agent log
+                    const finishedCount = data.fixtures.filter(f => f.finished === true).length;
+                    const startedCount = data.fixtures.filter(f => f.started === true && !f.finished).length;
+                    fetch('http://127.0.0.1:7242/ingest/f0cf0c26-f8c1-4bff-8dcd-6a0e660bef29',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'data.js:414',message:'Fixtures refreshed - checking finished/started counts',data:{totalFixtures:data.fixtures.length,finishedCount,startedCount,activeGW:getActiveGW()},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'B'})}).catch(()=>{});
+                    // #endregion
                     fplFixtures = data.fixtures;
                     console.log('✅ Fixtures refreshed');
                 }

--- a/frontend/src/fixtures.js
+++ b/frontend/src/fixtures.js
@@ -172,6 +172,16 @@ export function getMatchStatus(teamId, gameweek, player) {
     const isMatchFinished = fixture.finished ||
                            (hasGWStats && gwMinutes !== null && gwMinutes !== undefined);
 
+    // #region agent log
+    if (player && player.id) {
+        fetch('http://127.0.0.1:7242/ingest/f0cf0c26-f8c1-4bff-8dcd-6a0e660bef29',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'fixtures.js:173',message:'getMatchStatus - fixture flags and player data',data:{playerId:player.id,teamId,gameweek,fixtureStarted:fixture.started,fixtureFinished:fixture.finished,hasLiveStats,liveMinutes,hasGWStats,gwMinutes,isMatchFinished,fixtureId:fixture.id,kickoffTime:fixture.kickoff_time},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'A'})}).catch(()=>{});
+        fetch('http://127.0.0.1:7242/ingest/f0cf0c26-f8c1-4bff-8dcd-6a0e660bef29',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'fixtures.js:173',message:'getMatchStatus - fixture flags and player data',data:{playerId:player.id,teamId,gameweek,fixtureStarted:fixture.started,fixtureFinished:fixture.finished,hasLiveStats,liveMinutes,hasGWStats,gwMinutes,isMatchFinished,fixtureId:fixture.id,kickoffTime:fixture.kickoff_time},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'B'})}).catch(()=>{});
+        fetch('http://127.0.0.1:7242/ingest/f0cf0c26-f8c1-4bff-8dcd-6a0e660bef29',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'fixtures.js:173',message:'getMatchStatus - fixture flags and player data',data:{playerId:player.id,teamId,gameweek,fixtureStarted:fixture.started,fixtureFinished:fixture.finished,hasLiveStats,liveMinutes,hasGWStats,gwMinutes,isMatchFinished,fixtureId:fixture.id,kickoffTime:fixture.kickoff_time},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'C'})}).catch(()=>{});
+        fetch('http://127.0.0.1:7242/ingest/f0cf0c26-f8c1-4bff-8dcd-6a0e660bef29',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'fixtures.js:173',message:'getMatchStatus - fixture flags and player data',data:{playerId:player.id,teamId,gameweek,fixtureStarted:fixture.started,fixtureFinished:fixture.finished,hasLiveStats,liveMinutes,hasGWStats,gwMinutes,isMatchFinished,fixtureId:fixture.id,kickoffTime:fixture.kickoff_time},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'D'})}).catch(()=>{});
+        fetch('http://127.0.0.1:7242/ingest/f0cf0c26-f8c1-4bff-8dcd-6a0e660bef29',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'fixtures.js:173',message:'getMatchStatus - fixture flags and player data',data:{playerId:player.id,teamId,gameweek,fixtureStarted:fixture.started,fixtureFinished:fixture.finished,hasLiveStats,liveMinutes,hasGWStats,gwMinutes,isMatchFinished,fixtureId:fixture.id,kickoffTime:fixture.kickoff_time},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'E'})}).catch(()=>{});
+    }
+    // #endregion
+
     // 1. Match FINISHED
     if (isMatchFinished) {
         // Priority: live_stats > github_gw > explain
@@ -188,6 +198,14 @@ export function getMatchStatus(teamId, gameweek, player) {
             }
         }
 
+        // #region agent log
+        if (player && player.id) {
+            const statusResult = minutes !== null && minutes !== undefined ? `FT (${minutes})` : 'FT';
+            fetch('http://127.0.0.1:7242/ingest/f0cf0c26-f8c1-4bff-8dcd-6a0e660bef29',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'fixtures.js:195',message:'getMatchStatus - returning FT status',data:{playerId:player.id,statusResult,fixtureFinished:fixture.finished,hasGWStats,gwMinutes,liveMinutes,minutes},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'A'})}).catch(()=>{});
+            fetch('http://127.0.0.1:7242/ingest/f0cf0c26-f8c1-4bff-8dcd-6a0e660bef29',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'fixtures.js:195',message:'getMatchStatus - returning FT status',data:{playerId:player.id,statusResult,fixtureFinished:fixture.finished,hasGWStats,gwMinutes,liveMinutes,minutes},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'C'})}).catch(()=>{});
+        }
+        // #endregion
+
         if (minutes !== null && minutes !== undefined) {
             return `FT (${minutes})`;
         }
@@ -196,6 +214,13 @@ export function getMatchStatus(teamId, gameweek, player) {
 
     // 2. Match LIVE (started but not finished)
     if (fixture.started && !isMatchFinished) {
+        // #region agent log
+        if (player && player.id) {
+            const statusResult = liveMinutes !== null ? `LIVE (${liveMinutes})` : 'LIVE';
+            fetch('http://127.0.0.1:7242/ingest/f0cf0c26-f8c1-4bff-8dcd-6a0e660bef29',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'fixtures.js:198',message:'getMatchStatus - returning LIVE status',data:{playerId:player.id,statusResult,fixtureStarted:fixture.started,fixtureFinished:fixture.finished,isMatchFinished,liveMinutes},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'A'})}).catch(()=>{});
+            fetch('http://127.0.0.1:7242/ingest/f0cf0c26-f8c1-4bff-8dcd-6a0e660bef29',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'fixtures.js:198',message:'getMatchStatus - returning LIVE status',data:{playerId:player.id,statusResult,fixtureStarted:fixture.started,fixtureFinished:fixture.finished,isMatchFinished,liveMinutes},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'D'})}).catch(()=>{});
+        }
+        // #endregion
         if (liveMinutes !== null) {
             return `LIVE (${liveMinutes})`;
         }

--- a/frontend/src/renderMyTeam.js
+++ b/frontend/src/renderMyTeam.js
@@ -172,8 +172,16 @@ function setupTeamAutoRefresh() {
             if (stillLive) {
                 teamDataRefreshCount = 0;
                 startAutoRefresh(async () => {
+                    // #region agent log
+                    fetch('http://127.0.0.1:7242/ingest/f0cf0c26-f8c1-4bff-8dcd-6a0e660bef29',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'renderMyTeam.js:174',message:'Team page auto-refresh callback started',data:{teamDataRefreshCount,cycleNumber:teamDataRefreshCount + 1},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'B'})}).catch(()=>{});
+                    // #endregion
+
                     // Refresh enriched bootstrap every 2 min
                     await loadEnrichedBootstrap(true);
+
+                    // #region agent log
+                    fetch('http://127.0.0.1:7242/ingest/f0cf0c26-f8c1-4bff-8dcd-6a0e660bef29',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'renderMyTeam.js:177',message:'Enriched bootstrap refreshed in team auto-refresh',data:{teamDataRefreshCount},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'E'})}).catch(()=>{});
+                    // #endregion
 
                     // Refresh team data every 3rd cycle (every 6 min)
                     teamDataRefreshCount++;
@@ -185,6 +193,9 @@ function setupTeamAutoRefresh() {
                             try {
                                 const teamData = await loadMyTeam(teamId, { forceRefresh: true });
                                 myTeamState.teamData = teamData;
+                                // #region agent log
+                                fetch('http://127.0.0.1:7242/ingest/f0cf0c26-f8c1-4bff-8dcd-6a0e660bef29',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'renderMyTeam.js:187',message:'Team data refreshed in auto-refresh',data:{teamId},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'E'})}).catch(()=>{});
+                                // #endregion
                             } catch (err) {
                                 console.error('Failed to refresh team data:', err);
                                 // Show warning toast for 503 errors
@@ -197,6 +208,9 @@ function setupTeamAutoRefresh() {
 
                     // Re-render current tab
                     if (myTeamState.teamData) {
+                        // #region agent log
+                        fetch('http://127.0.0.1:7242/ingest/f0cf0c26-f8c1-4bff-8dcd-6a0e660bef29',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'renderMyTeam.js:200',message:'Re-rendering team page after auto-refresh',data:{currentTab:myTeamState.currentTab},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'B'})}).catch(()=>{});
+                        // #endregion
                         renderMyTeam(myTeamState.teamData, myTeamState.currentTab);
                     }
                 });


### PR DESCRIPTION
- Implemented multiple fetch calls to log player and fixture data during match status checks in `getMatchStatus`.
- Added logging for finished and started fixture counts in `startAutoRefresh`.
- Enhanced team auto-refresh with logging for various stages, including bootstrap refresh and team data updates.
- Structured logs to include relevant data points for debugging and analysis.