### PR TITLE
Fix OOM crash (exit 134) on Render by reducing memory pressure

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "type": "module",
   "scripts": {
-    "start": "node server.js",
+    "start": "node --max-old-space-size=384 server.js",
     "dev": "node --watch server.js",
     "test": "vitest",
     "test:run": "vitest run"


### PR DESCRIPTION
- Set --max-old-space-size=384 to keep V8 heap within Render's 512MB limit
- Cap team/picks cache Maps (200/400 entries) with oldest-first eviction
- Add periodic pruning of expired cache entries every 5 minutes
- Replace deep clone in /api/bootstrap/enriched with direct references
- Stream cache backup to disk instead of building full JSON string in memory
- Increase cache save interval from 5 to 15 minutes