### PR TITLE
Add Double Gameweek (DGW) support across mobile UI

### DIFF
--- a/frontend/src/myTeam/compact/compactBubbleFormation.js
+++ b/frontend/src/myTeam/compact/compactBubbleFormation.js
@@ -5,7 +5,7 @@
 
 import { getPlayerById, getActiveGW } from '../../data.js';
 import { getPositionShort, escapeHtml } from '../../utils.js';
-import { getGWOpponent } from '../../fixtures.js';
+import { getGWOpponents } from '../../fixtures.js';
 import { calculateGWPointsBreakdown, showPlayerModal } from './playerModal.js';
 import { getGlassmorphism, getShadow, getMobileBorderRadius } from '../../styles/mobileDesignSystem.js';
 
@@ -537,9 +537,9 @@ export async function initBubbleFormationChart(players, gwNumber, isLive, myTeam
             const fontSize = getFontSize(size);
             const colors = getPointsColors(gwPoints, minutes);
 
-            // Get opponent data
-            const opponent = getGWOpponent(player.team, gwNumber);
-            const opponentText = opponent ? `${opponent.name} (${opponent.isHome ? 'H' : 'A'})` : 'TBD';
+            // Get opponent data (DGW-aware)
+            const opponents = getGWOpponents(player.team, gwNumber);
+            const opponentText = opponents.map(o => `${o.name}(${o.isHome ? 'H' : 'A'})`).join(', ');
 
             // Calculate font sizes for rich text
             const nameFontSize = fontSize; // Base size for name
@@ -659,9 +659,9 @@ export async function initBubbleFormationChart(players, gwNumber, isLive, myTeam
                 const fontSize = getFontSize(size);
                 const colors = getPointsColors(gwPoints, minutes);
 
-                // Get opponent data
-                const opponent = getGWOpponent(player.team, gwNumber);
-                const opponentText = opponent ? `${opponent.name} (${opponent.isHome ? 'H' : 'A'})` : 'TBD';
+                // Get opponent data (DGW-aware)
+                const opponents = getGWOpponents(player.team, gwNumber);
+                const opponentText = opponents.map(o => `${o.name}(${o.isHome ? 'H' : 'A'})`).join(', ');
 
                 // Calculate font sizes for rich text
                 const nameFontSize = fontSize; // Base size for name

--- a/frontend/src/myTeam/compact/compactFixturesTicker.js
+++ b/frontend/src/myTeam/compact/compactFixturesTicker.js
@@ -15,7 +15,7 @@ import {
 import { renderFixturePlayerStats } from '../fixturesTab.js';
 import { escapeHtml, getDifficultyClass } from '../../utils.js';
 import { getGlassmorphism, getShadow, getMobileBorderRadius } from '../../styles/mobileDesignSystem.js';
-import { getMatchStatus } from '../../fixtures.js';
+import { getMatchStatus, isDoubleGameweek } from '../../fixtures.js';
 import { renderTeamLogo } from '../../utils/teamLogos.js';
 
 /**
@@ -339,6 +339,18 @@ export function renderFixturesTicker() {
         window.showFixtureModal = showFixtureModal;
     }
 
+    const isDGW = isDoubleGameweek(targetGW);
+    const dgwBadge = isDGW ? `<span style="
+        background: rgba(147, 51, 234, 0.15);
+        color: #a855f6;
+        font-weight: 700;
+        font-size: 0.6rem;
+        padding: 0.2rem 0.4rem;
+        border-radius: 4px;
+        white-space: nowrap;
+        flex-shrink: 0;
+    ">DGW${targetGW}</span>` : '';
+
     return `
         <div class="fixtures-ticker-container" style="
             width: 100%;
@@ -354,9 +366,11 @@ export function renderFixturesTicker() {
             <div class="fixtures-ticker" style="
                 display: flex;
                 flex-direction: row;
+                align-items: center;
                 gap: 0;
                 min-width: max-content;
             ">
+                ${dgwBadge ? `<div style="padding: 0 0.4rem; flex-shrink: 0;">${dgwBadge}</div>` : ''}
                 ${fixtureCards}
             </div>
         </div>

--- a/frontend/src/myTeam/compact/compactHeader.js
+++ b/frontend/src/myTeam/compact/compactHeader.js
@@ -5,9 +5,9 @@
 
 import { getPlayerById, loadTransferHistory, getActiveGW, getGameweekEvent, getAllPlayers } from '../../data.js';
 import { escapeHtml } from '../../utils.js';
-import { getGWOpponent } from '../../fixtures.js';
+import { getGWOpponents } from '../../fixtures.js';
 import {
-    renderOpponentBadge,
+    renderOpponentBadges,
     calculateRankIndicator,
     calculateGWIndicator
 } from './compactStyleHelpers.js';
@@ -130,11 +130,13 @@ function calculateGWFDR(teamData, gwNumber) {
     let count = 0;
 
     starting11.forEach(player => {
-        const oppInfo = getGWOpponent(player.team, gwNumber);
-        if (oppInfo && oppInfo.difficulty) {
-            totalFDR += oppInfo.difficulty;
-            count++;
-        }
+        const opps = getGWOpponents(player.team, gwNumber);
+        opps.forEach(oppInfo => {
+            if (oppInfo && oppInfo.difficulty) {
+                totalFDR += oppInfo.difficulty;
+                count++;
+            }
+        });
     });
 
     return count > 0 ? totalFDR / count : null;
@@ -323,18 +325,18 @@ function getCaptainViceInfo(picks, gwNumber) {
     if (captainPick) {
         const captainPlayer = getPlayerById(captainPick.element);
         if (captainPlayer) {
-            const captainOpp = getGWOpponent(captainPlayer.team, gwNumber);
-            const oppBadge = renderOpponentBadge(captainOpp, 'normal');
-            captainInfo = `${captainPlayer.web_name} vs. ${oppBadge}`;
+            const captainOpps = getGWOpponents(captainPlayer.team, gwNumber);
+            const oppBadges = renderOpponentBadges(captainOpps, 'normal');
+            captainInfo = `${captainPlayer.web_name} vs. ${oppBadges}`;
         }
     }
 
     if (vicePick) {
         const vicePlayer = getPlayerById(vicePick.element);
         if (vicePlayer) {
-            const viceOpp = getGWOpponent(vicePlayer.team, gwNumber);
-            const oppBadge = renderOpponentBadge(viceOpp, 'normal');
-            viceInfo = `${vicePlayer.web_name} vs. ${oppBadge}`;
+            const viceOpps = getGWOpponents(vicePlayer.team, gwNumber);
+            const oppBadges = renderOpponentBadges(viceOpps, 'normal');
+            viceInfo = `${vicePlayer.web_name} vs. ${oppBadges}`;
         }
     }
 

--- a/frontend/src/myTeam/compact/compactPlayerRow.js
+++ b/frontend/src/myTeam/compact/compactPlayerRow.js
@@ -13,9 +13,10 @@ import {
     formatCurrency,
     getPositionShort
 } from '../../utils.js';
-import { getGWOpponent, getMatchStatus } from '../../fixtures.js';
+import { getGWOpponents, getMatchStatuses } from '../../fixtures.js';
 import {
-    renderOpponentBadge,
+    renderOpponentBadges,
+    renderStatusBadges,
     calculateStatusColor,
     calculatePlayerBgColor
 } from './compactStyleHelpers.js';
@@ -47,11 +48,10 @@ export function renderCompactPlayerRow(pick, player, gwNumber) {
     if (isGuillotinedPlayer) badges.push('🔪');
     const badgeMarkup = badges.length > 0 ? ` <span style="font-size: 0.65rem;">${badges.join(' ')}</span>` : '';
 
-    const gwOpp = getGWOpponent(player.team, gwNumber);
+    const gwOpps = getGWOpponents(player.team, gwNumber);
 
-    // Get match status display with color coding
-    const matchStatus = getMatchStatus(player.team, gwNumber, player);
-    const statusColors = calculateStatusColor(matchStatus);
+    // Get match status display with color coding (DGW-aware)
+    const matchStatuses = getMatchStatuses(player.team, gwNumber, player);
 
     // Get GW-specific stats - prioritize live_stats from enriched bootstrap
     const hasGWStats = player.github_gw && player.github_gw.gw === gwNumber;
@@ -132,10 +132,10 @@ export function renderCompactPlayerRow(pick, player, gwNumber) {
                 ${riskContextMessage ? `<div style="font-size: 0.6rem; color: ${riskContextColor}; line-height: 1.2; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${escapeHtml(riskContextMessage)}</div>` : '<div style="height: 0.8rem;"></div>'}
             </div>
             <div style="text-align: center;">
-                ${renderOpponentBadge(gwOpp, 'small')}
+                ${renderOpponentBadges(gwOpps, 'small')}
             </div>
             <div style="text-align: center; padding: 0.5rem;">
-                <span style="display: inline-block; padding: 0.2rem 0.4rem; border-radius: 3px; font-weight: 600; font-size: 0.65rem; background: ${statusColors.statusBgColor}; color: ${statusColors.statusColor}; white-space: nowrap;">${matchStatus}</span>
+                ${renderStatusBadges(matchStatuses, calculateStatusColor)}
             </div>
             <div style="text-align: center; padding: 0.5rem;">
                 <span style="display: inline-block; padding: 0.2rem 0.4rem; border-radius: 3px; font-weight: 600; font-size: 0.65rem; background: ${ptsStyle.background}; color: ${ptsStyle.color};">${displayPoints}</span>

--- a/frontend/src/myTeam/compact/compactSchedule.js
+++ b/frontend/src/myTeam/compact/compactSchedule.js
@@ -3,8 +3,7 @@
 // Match schedule section (collapsible) for GW fixtures
 // ============================================================================
 
-import { getPlayerById } from '../../data.js';
-import { getFixtures } from '../../fixtures.js';
+import { getPlayerById, fplFixtures } from '../../data.js';
 import { getTeamShortName } from '../../utils.js';
 import { getGlassmorphism, getShadow, getMobileBorderRadius } from '../../styles/mobileDesignSystem.js';
 
@@ -15,8 +14,8 @@ import { getGlassmorphism, getShadow, getMobileBorderRadius } from '../../styles
  * @returns {string} HTML for match schedule
  */
 export function renderMatchSchedule(players, gwNumber) {
-    const fixtures = getFixtures();
-    const gwFixtures = fixtures.filter(f => f.event === gwNumber);
+    if (!fplFixtures) return '';
+    const gwFixtures = fplFixtures.filter(f => f.event === gwNumber);
 
     // Get unique team IDs from player squad
     const teamIds = new Set(players.map(p => {

--- a/frontend/src/myTeam/compact/compactStyleHelpers.js
+++ b/frontend/src/myTeam/compact/compactStyleHelpers.js
@@ -19,6 +19,44 @@ export function renderOpponentBadge(opponent, size = 'normal') {
 }
 
 /**
+ * Render one or more opponent badges (handles DGW with stacked display)
+ * @param {OpponentInfo[]} opponents - Array from getGWOpponents()
+ * @param {string} size - 'small' or 'normal'
+ * @returns {string} HTML - single badge for SGW, vertically stacked for DGW
+ */
+export function renderOpponentBadges(opponents, size = 'normal') {
+    if (!opponents || opponents.length === 0) {
+        return renderOpponentBadge({ name: 'TBD', difficulty: 3, isHome: false }, size);
+    }
+    if (opponents.length === 1) {
+        return renderOpponentBadge(opponents[0], size);
+    }
+    return `<div style="display: flex; flex-direction: column; gap: 1px; align-items: center;">
+        ${opponents.map(opp => renderOpponentBadge(opp, size)).join('')}
+    </div>`;
+}
+
+/**
+ * Render one or more match status badges (handles DGW with stacked display)
+ * @param {string[]} statuses - Array of status strings from getMatchStatuses()
+ * @param {Function} calculateStatusColorFn - The calculateStatusColor function
+ * @returns {string} HTML - single badge for SGW, vertically stacked for DGW
+ */
+export function renderStatusBadges(statuses, calculateStatusColorFn) {
+    if (!statuses || statuses.length === 0) return '';
+    if (statuses.length === 1) {
+        const colors = calculateStatusColorFn(statuses[0]);
+        return `<span style="display: inline-block; padding: 0.2rem 0.4rem; border-radius: 3px; font-weight: 600; font-size: 0.65rem; background: ${colors.statusBgColor}; color: ${colors.statusColor}; white-space: nowrap;">${statuses[0]}</span>`;
+    }
+    return `<div style="display: flex; flex-direction: column; gap: 1px; align-items: center;">
+        ${statuses.map(status => {
+            const colors = calculateStatusColorFn(status);
+            return `<span style="display: inline-block; padding: 0.15rem 0.3rem; border-radius: 3px; font-weight: 600; font-size: 0.55rem; background: ${colors.statusBgColor}; color: ${colors.statusColor}; white-space: nowrap;">${status}</span>`;
+        }).join('')}
+    </div>`;
+}
+
+/**
  * Render stat card for modal
  * @param {string|number} value - Stat value
  * @param {string} label - Stat label

--- a/frontend/src/myTeam/compact/compactTeamList.js
+++ b/frontend/src/myTeam/compact/compactTeamList.js
@@ -16,8 +16,8 @@ import {
     calculatePPM,
     getTeamShortName
 } from '../../utils.js';
-import { getFixtures, getGWOpponent, getMatchStatus } from '../../fixtures.js';
-import { calculateStatusColor } from './compactStyleHelpers.js';
+import { getFixtures, getGWOpponents, getMatchStatuses } from '../../fixtures.js';
+import { calculateStatusColor, renderOpponentBadges, renderStatusBadges } from './compactStyleHelpers.js';
 import { isWishlisted } from '../../wishlist/store.js';
 import { isGuillotined } from '../../guillotine/store.js';
 import { getGlassmorphism, getShadow, getMobileBorderRadius } from '../../styles/mobileDesignSystem.js';
@@ -107,8 +107,8 @@ function renderTeamSection(players, gwNumber, isLive, next5GWs, activeGW, sectio
             }
         }
 
-        // Current GW opponent for Opp column (use active GW, not gwNumber)
-        const opponent = getGWOpponent(player.team, activeGW);
+        // Current GW opponents for Opp column (use active GW, not gwNumber)
+        const opponents = getGWOpponents(player.team, activeGW);
 
         // Calculate GW points with captain doubling (use gwNumber for points data)
         const hasGWStats = player.github_gw && player.github_gw.gw === gwNumber;
@@ -152,9 +152,8 @@ function renderTeamSection(players, gwNumber, isLive, next5GWs, activeGW, sectio
         // Next 5 fixtures
         const next5Fixtures = getFixtures(player.team, 5, false);
 
-        // Match status display with color coding
-        const matchStatus = getMatchStatus(player.team, gwNumber, player);
-        const statusColors = calculateStatusColor(matchStatus);
+        // Match status display with color coding (DGW-aware)
+        const matchStatuses = getMatchStatuses(player.team, gwNumber, player);
 
         // Row styling
         const rowBg = idx % 2 === 0 ? 'var(--bg-primary)' : 'var(--bg-secondary)';
@@ -204,12 +203,10 @@ function renderTeamSection(players, gwNumber, isLive, next5GWs, activeGW, sectio
                     </div>
                 </td>
                 <td style="text-align: center; padding: 0.5rem;">
-                    <span class="${getDifficultyClass(opponent.difficulty)}" style="display: inline-block; width: 52px; padding: 0.2rem 0.3rem; border-radius: 3px; font-weight: 600; font-size: 0.6rem; text-align: center;">
-                        ${opponent.name} (${opponent.isHome ? 'H' : 'A'})
-                    </span>
+                    ${renderOpponentBadges(opponents, 'small')}
                 </td>
                 <td style="text-align: center; padding: 0.5rem;">
-                    <span style="display: inline-block; padding: 0.2rem 0.4rem; border-radius: 3px; font-weight: 600; font-size: 0.65rem; background: ${statusColors.statusBgColor}; color: ${statusColors.statusColor}; white-space: nowrap;">${matchStatus}</span>
+                    ${renderStatusBadges(matchStatuses, calculateStatusColor)}
                 </td>
                 <td style="text-align: center; padding: 0.5rem;">
                     <span style="display: inline-block; padding: 0.2rem 0.4rem; border-radius: 3px; font-weight: 600; font-size: 0.65rem; background: ${ptsStyle.background}; color: ${ptsStyle.color};">${displayPoints}</span>

--- a/frontend/src/myTeam/fixturesTab.js
+++ b/frontend/src/myTeam/fixturesTab.js
@@ -16,7 +16,7 @@ import {
     getPositionShort,
     formatDecimal
 } from '../utils.js';
-import { getMatchStatus } from '../fixtures.js';
+import { getMatchStatus, isDoubleGameweek } from '../fixtures.js';
 
 /**
  * Get top performers for a fixture (both teams)
@@ -510,6 +510,7 @@ export function renderFixturesTab() {
                     ">
                         <i class="fas fa-calendar-alt" style="color: var(--primary-color);"></i>
                         <span>Gameweek ${gw}</span>
+                        ${isDoubleGameweek(parseInt(gw)) ? '<span style="background: rgba(147, 51, 234, 0.15); color: #a855f6; font-weight: 700; font-size: 0.7rem; padding: 0.15rem 0.4rem; border-radius: 4px;">DGW</span>' : ''}
                     </h3>
                     <div style="overflow-x: auto;">
                         <table style="width: 100%; font-size: 0.875rem; border-collapse: collapse;">
@@ -827,6 +828,7 @@ export function renderMobileFixturesTab() {
                         ">
                             <i class="fas fa-calendar-alt" style="color: var(--primary-color);"></i>
                             <span>Gameweek ${gw}</span>
+                            ${isDoubleGameweek(parseInt(gw)) ? '<span style="background: rgba(147, 51, 234, 0.15); color: #a855f6; font-weight: 700; font-size: 0.7rem; padding: 0.15rem 0.4rem; border-radius: 4px;">DGW</span>' : ''}
                         </h4>
                     </div>
                     ${dateSections}


### PR DESCRIPTION
Show all opponents and match statuses for DGW players instead of only the first fixture. Add purple DGW badge to fixtures ticker, desktop and mobile GW headers. Fix compactSchedule.js using wrong data source.