### PR TITLE
Fix DGW bubble text wrapping and add stacked opponents to standings/t…

### DIFF
--- a/frontend/src/myTeam/compact/compactBubbleFormation.js
+++ b/frontend/src/myTeam/compact/compactBubbleFormation.js
@@ -539,14 +539,21 @@ export async function initBubbleFormationChart(players, gwNumber, isLive, myTeam
 
             // Get opponent data (DGW-aware)
             const opponents = getGWOpponents(player.team, gwNumber);
-            const opponentText = opponents.map(o => `${o.name}(${o.isHome ? 'H' : 'A'})`).join(', ');
 
             // Calculate font sizes for rich text
             const nameFontSize = fontSize; // Base size for name
             const statsFontSize = Math.max(6, Math.floor(fontSize * 0.7)); // 70% of base, minimum 6px
 
-            // Create rich text formatter
-            const labelFormatter = `{name|${escapeHtml(player.web_name)}}\n{stats|${gwPoints} vs. ${escapeHtml(opponentText)}}`;
+            // Create rich text formatter — split DGW opponents onto separate lines
+            let labelFormatter;
+            if (opponents.length > 1) {
+                const opp1 = `${opponents[0].name}(${opponents[0].isHome ? 'H' : 'A'})`;
+                const opp2 = `${opponents[1].name}(${opponents[1].isHome ? 'H' : 'A'})`;
+                labelFormatter = `{name|${escapeHtml(player.web_name)}}\n{stats|${gwPoints} vs ${escapeHtml(opp1)}}\n{stats2|& ${escapeHtml(opp2)}}`;
+            } else {
+                const opponentText = opponents.map(o => `${o.name}(${o.isHome ? 'H' : 'A'})`).join('');
+                labelFormatter = `{name|${escapeHtml(player.web_name)}}\n{stats|${gwPoints} vs. ${escapeHtml(opponentText)}}`;
+            }
 
             allNodes.push({
                 name: player.web_name,
@@ -576,6 +583,14 @@ export async function initBubbleFormationChart(players, gwNumber, isLive, myTeam
                             lineHeight: nameFontSize * 1.2
                         },
                         stats: {
+                            fontSize: statsFontSize,
+                            fontWeight: 'normal',
+                            color: colors.textColor,
+                            textBorderColor: 'rgba(0, 0, 0, 0.3)',
+                            textBorderWidth: 0.5,
+                            lineHeight: statsFontSize * 1.1
+                        },
+                        stats2: {
                             fontSize: statsFontSize,
                             fontWeight: 'normal',
                             color: colors.textColor,
@@ -661,14 +676,21 @@ export async function initBubbleFormationChart(players, gwNumber, isLive, myTeam
 
                 // Get opponent data (DGW-aware)
                 const opponents = getGWOpponents(player.team, gwNumber);
-                const opponentText = opponents.map(o => `${o.name}(${o.isHome ? 'H' : 'A'})`).join(', ');
 
                 // Calculate font sizes for rich text
                 const nameFontSize = fontSize; // Base size for name
                 const statsFontSize = Math.max(6, Math.floor(fontSize * 0.7)); // 70% of base, minimum 6px
 
-                // Create rich text formatter
-                const labelFormatter = `{name|${escapeHtml(player.web_name)}}\n{stats|${gwPoints} vs. ${escapeHtml(opponentText)}}`;
+                // Create rich text formatter — split DGW opponents onto separate lines
+                let labelFormatter;
+                if (opponents.length > 1) {
+                    const opp1 = `${opponents[0].name}(${opponents[0].isHome ? 'H' : 'A'})`;
+                    const opp2 = `${opponents[1].name}(${opponents[1].isHome ? 'H' : 'A'})`;
+                    labelFormatter = `{name|${escapeHtml(player.web_name)}}\n{stats|${gwPoints} vs ${escapeHtml(opp1)}}\n{stats2|& ${escapeHtml(opp2)}}`;
+                } else {
+                    const opponentText = opponents.map(o => `${o.name}(${o.isHome ? 'H' : 'A'})`).join('');
+                    labelFormatter = `{name|${escapeHtml(player.web_name)}}\n{stats|${gwPoints} vs. ${escapeHtml(opponentText)}}`;
+                }
 
                 allNodes.push({
                     name: player.web_name,
@@ -697,6 +719,14 @@ export async function initBubbleFormationChart(players, gwNumber, isLive, myTeam
                                 lineHeight: nameFontSize * 1.2
                             },
                             stats: {
+                                fontSize: statsFontSize,
+                                fontWeight: 'normal',
+                                color: colors.textColor,
+                                textBorderColor: 'rgba(0, 0, 0, 0.3)',
+                                textBorderWidth: 0.5,
+                                lineHeight: statsFontSize * 1.1
+                            },
+                            stats2: {
                                 fontSize: statsFontSize,
                                 fontWeight: 'normal',
                                 color: colors.textColor,

--- a/frontend/src/myTeam/leagueStandings.js
+++ b/frontend/src/myTeam/leagueStandings.js
@@ -7,8 +7,8 @@ import { loadLeagueStandings, loadMyTeam, getPlayerById, getActiveGW, isGameweek
 import { escapeHtml, formatDecimal, getPtsHeatmap, getFormHeatmap, getHeatmapStyle, calculatePPM } from '../utils.js';
 import { renderTeamComparison } from './teamComparison.js';
 import { shouldUseMobileLayout } from '../renderMyTeamMobile.js';
-import { getGWOpponent, getMatchStatus, calculateFixtureDifficulty } from '../fixtures.js';
-import { renderOpponentBadge, calculateStatusColor, calculatePlayerBgColor } from './compact/compactStyleHelpers.js';
+import { getGWOpponents, getMatchStatuses, calculateFixtureDifficulty } from '../fixtures.js';
+import { renderOpponentBadges, renderStatusBadges, calculateStatusColor, calculatePlayerBgColor } from './compact/compactStyleHelpers.js';
 import { getGlassmorphism, getShadow, getMobileBorderRadius } from '../styles/mobileDesignSystem.js';
 
 /**
@@ -1193,10 +1193,9 @@ function renderMobileRivalModal(rivalTeamData, myTeamState = null) {
         if (isMyPlayer) badges.push('👤');
         const badgeMarkup = badges.length > 0 ? ` <span style="font-size: 0.65rem;">${badges.join(' ')}</span>` : '';
 
-        // Get opponent and match status
-        const gwOpp = getGWOpponent(player.team, gwNumber);
-        const matchStatus = getMatchStatus(player.team, gwNumber, player);
-        const statusColors = calculateStatusColor(matchStatus);
+        // Get opponent and match status (DGW-aware)
+        const gwOpps = getGWOpponents(player.team, gwNumber);
+        const matchStatuses = getMatchStatuses(player.team, gwNumber, player);
 
         // Calculate points with captain multiplier
         const gwPoints = player.event_points || 0;
@@ -1227,10 +1226,10 @@ function renderMobileRivalModal(rivalTeamData, myTeamState = null) {
                     ${escapeHtml(player.web_name)}${captainBadge}${badgeMarkup}
                 </div>
                 <div style="text-align: center;">
-                    ${renderOpponentBadge(gwOpp, 'small')}
+                    ${renderOpponentBadges(gwOpps, 'small')}
                 </div>
                 <div style="text-align: center; padding: 0.5rem;">
-                    <span style="display: inline-block; padding: 0.2rem 0.4rem; border-radius: 3px; font-weight: 600; font-size: 0.65rem; background: ${statusColors.statusBgColor}; color: ${statusColors.statusColor}; white-space: nowrap;">${matchStatus}</span>
+                    ${renderStatusBadges(matchStatuses, calculateStatusColor)}
                 </div>
                 <div style="text-align: center; padding: 0.5rem;">
                     <span style="display: inline-block; padding: 0.2rem 0.4rem; border-radius: 3px; font-weight: 600; font-size: 0.65rem; background: ${ptsStyle.background}; color: ${ptsStyle.color};">${displayPoints}</span>

--- a/frontend/src/myTeam/teamTable.js
+++ b/frontend/src/myTeam/teamTable.js
@@ -20,7 +20,7 @@ import {
 
 import {
     getFixtures,
-    getGWOpponent
+    getGWOpponents
 } from '../fixtures.js';
 
 import {
@@ -115,7 +115,7 @@ function renderTeamRows(players, gameweek, next5GWs) {
         if (isCaptain) captainBadge = ' <span style="color: var(--primary-color); font-weight: 700;">(C)</span>';
         if (isVice) captainBadge = ' <span style="color: var(--text-secondary); font-weight: 700;">(VC)</span>';
 
-        const gwOpp = getGWOpponent(player.team, gameweek);
+        const gwOpps = getGWOpponents(player.team, gameweek);
         const posType = getPositionType(player);
         const risks = analyzePlayerRisks(player);
         const riskTooltip = renderRiskTooltip(risks);
@@ -185,9 +185,7 @@ function renderTeamRows(players, gameweek, next5GWs) {
                 </td>
                 <td style="padding: 0.75rem 0.5rem;">${getTeamShortName(player.team)}</td>
                 <td style="padding: 0.75rem 0.5rem; text-align: center;">
-                    <span class="${getDifficultyClass(gwOpp.difficulty)}" style="padding: 0.25rem 0.5rem; border-radius: 0.25rem; font-weight: 600; font-size: 0.75rem; min-width: 5rem; display: inline-block; text-align: center;">
-                        ${gwOpp.name}${gwOpp.isHome ? ' (H)' : ' (A)'}
-                    </span>
+                    ${gwOpps.map(opp => `<span class="${getDifficultyClass(opp.difficulty)}" style="padding: 0.25rem 0.5rem; border-radius: 0.25rem; font-weight: 600; font-size: 0.75rem; min-width: 5rem; display: inline-block; text-align: center;">${opp.name}${opp.isHome ? ' (H)' : ' (A)'}</span>`).join(' ')}
                 </td>
                 <td style="padding: 0.75rem 0.5rem; text-align: center; font-size: 0.8rem;">
                     ${gwMinutes}


### PR DESCRIPTION
…able

Split DGW opponents onto separate lines in bubble formation labels instead of comma-joining on one line. Update leagueStandings.js and teamTable.js to use plural getGWOpponents/renderOpponentBadges for DGW support.