### PR TITLE
Revert Gemini model to preview — API key was revoked by Google

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -32,7 +32,7 @@ export const GITHUB_BASE_URL = 'https://raw.githubusercontent.com/olbauday/FPL-E
 // Gemini AI API
 export const GEMINI = {
   API_KEY: process.env.GEMINI_API_KEY || '',
-  API_URL: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent',
+  API_URL: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-09-2025:generateContent',
 };
 
 /**


### PR DESCRIPTION
The old API key was exposed in git history (backend/.env.example) and Google revoked it. Revert model to gemini-2.5-flash-preview-09-2025 until a new key is generated and set on Render.