### PR TITLE
Squad Doctor: collapse by default, add Current GW tab, fix captain pr…

### DIFF
--- a/backend/services/aiService.js
+++ b/backend/services/aiService.js
@@ -103,15 +103,22 @@ SQUAD ANALYSIS DATA:
 ${dataSnapshot}
 
 INSTRUCTIONS:
-- Produce exactly three bullet-style insights for each of the four categories below (12 total statements).
+- Produce exactly three bullet-style insights for each of the five categories below (15 total statements).
 - Every insight MUST reference a specific player name, fixture, stat, or price from the data provided. Never invent data.
 - Keep each insight to 1-2 sentences (max 40 words). Be decisive—say "sell", "bench", "captain", not "consider" or "monitor".
 - When identifying drop candidates, compare the player's form, fixtures, and price to cheaper alternatives available in the data.
+- The captain shown in the data is ALREADY LOCKED for the current gameweek. Do NOT recommend changing captain for the current gameweek. Instead, recommend the best captain for NEXT gameweek based on upcoming fixtures.
 - For captain picks, weigh form (last 4 GW average), fixture difficulty, home/away, and double gameweek potential.
 - If transfer or league data is provided, factor in recent moves (don't re-recommend), budget constraints, and competitive urgency.
+- For the "Current GW" category: if currentGWData.isLive is true, review how the squad is performing (who returned points, who blanked, captain result, auto-sub implications). If isLive is false, preview opponents and difficulty for the upcoming deadline — suggest last-minute bench order or transfer targets.
 
 OUTPUT JSON SCHEMA:
 {
+  "Current GW": [
+    "Captain performance or opponent preview for current gameweek",
+    "Key starter result or bench decision review",
+    "Auto-sub implication or points projection"
+  ],
   "Squad Health": [
     "Insight about injury/suspension risks or bench cover gaps",
     "Insight about rotation-prone or low-minutes players in starting XI",
@@ -123,9 +130,9 @@ OUTPUT JSON SCHEMA:
     "Second transfer priority or hold recommendation with justification"
   ],
   "Captain Pick": [
-    "Recommended captain for next GW with form + fixture reasoning",
-    "Alternative captain option (differential or safer pick)",
-    "Vice-captain recommendation and reasoning"
+    "Best captain choice for NEXT GW with form + fixture reasoning",
+    "Differential captain option for next GW",
+    "Vice-captain recommendation for next GW"
   ],
   "Chip Strategy": [
     "Recommended chip timing based on fixture swings and DGW calendar",
@@ -279,7 +286,7 @@ export function parseGeminiResponse(geminiData, gameweek, page) {
     if (page === 'planner') {
       expectedCategories = ['Planner'];
     } else if (page === 'my-team') {
-      expectedCategories = ['Squad Health', 'Transfer Priorities', 'Captain Pick', 'Chip Strategy'];
+      expectedCategories = ['Current GW', 'Squad Health', 'Transfer Priorities', 'Captain Pick', 'Chip Strategy'];
     } else {
       expectedCategories = ['Overview', 'Hidden Gems', 'Differentials', 'Transfer Targets', 'Team Analysis'];
     }
@@ -360,7 +367,7 @@ export function parseGeminiResponse(geminiData, gameweek, page) {
     const fallbackKeys = page === 'planner'
       ? ['Planner']
       : page === 'my-team'
-        ? ['Squad Health', 'Transfer Priorities', 'Captain Pick', 'Chip Strategy']
+        ? ['Current GW', 'Squad Health', 'Transfer Priorities', 'Captain Pick', 'Chip Strategy']
         : ['Overview', 'Hidden Gems', 'Differentials', 'Transfer Targets', 'Team Analysis'];
 
     for (const category of fallbackKeys) {

--- a/frontend/src/renderInsightBanner.js
+++ b/frontend/src/renderInsightBanner.js
@@ -211,7 +211,7 @@ function renderCategoryInsights(insights, isMobile = false) {
  * @returns {string} HTML string
  */
 export function renderInsightBanner(insights, contextId, isMobile = false, options = {}) {
-    const { hideTabs = false, customTitle, customSubtitle, preferredCategory, hideRegenerateButton = false } = options;
+    const { hideTabs = false, customTitle, customSubtitle, preferredCategory, hideRegenerateButton = false, hideTitle = false } = options;
 
     // Handle error state (including parse errors from backend)
     if (insights.error || insights.parseError || !insights.categories || Object.keys(insights.categories).length === 0) {
@@ -260,7 +260,7 @@ export function renderInsightBanner(insights, contextId, isMobile = false, optio
                     flex-wrap: wrap;
                     align-items: flex-start;
                 ">
-                    <div style="flex: 1 1 auto; min-width: 150px;">
+                    ${hideTitle ? '' : `<div style="flex: 1 1 auto; min-width: 150px;">
                         <h3 style="
                             color: var(--accent-color);
                             font-weight: 700;
@@ -278,7 +278,7 @@ export function renderInsightBanner(insights, contextId, isMobile = false, optio
                                 ${customSubtitle}
                             </p>
                         ` : ''}
-                    </div>
+                    </div>`}
                     ${hideRegenerateButton ? '' : `
                         <button
                             class="ai-insights-regenerate-btn"

--- a/frontend/src/renderMyTeam.js
+++ b/frontend/src/renderMyTeam.js
@@ -550,6 +550,18 @@ export async function renderMyTeam(teamData, subTab = 'overview') {
 
                 // Load AI insights (non-blocking, renders into container when ready)
                 loadMyTeamAIInsights(teamData);
+
+                // Attach collapse/expand toggle for Squad Doctor
+                const aiHeader = document.getElementById('my-team-ai-insights-header');
+                const aiContainer = document.getElementById('my-team-ai-insights-container');
+                const aiChevron = document.getElementById('my-team-ai-chevron');
+                if (aiHeader && aiContainer && aiChevron) {
+                    aiHeader.addEventListener('click', () => {
+                        const isOpen = aiContainer.style.display !== 'none';
+                        aiContainer.style.display = isOpen ? 'none' : 'block';
+                        aiChevron.style.transform = isOpen ? 'rotate(0deg)' : 'rotate(180deg)';
+                    });
+                }
             } else if (subTab === 'fixtures') {
                 attachMobileFixtureRowListeners();
             }
@@ -866,8 +878,8 @@ async function loadMyTeamAIInsights(teamData) {
         };
 
         await loadAndRenderInsights(context, 'my-team-ai-insights-container', isMobile, {
-            customTitle: '🩺 Squad Doctor',
-            preferredCategory: 'Transfer Priorities'
+            hideTitle: true,
+            preferredCategory: 'Current GW'
         });
     } catch (error) {
         console.error('Failed to load My Team AI insights:', error);
@@ -900,7 +912,23 @@ async function renderTeamOverviewTab(teamData) {
         return `
             ${renderFixturesTicker()}
             <div style="padding: 0.75rem;">
-                <div id="my-team-ai-insights-container"></div>
+                <div id="my-team-ai-insights-wrapper" style="margin-bottom: 0.75rem;">
+                    <div id="my-team-ai-insights-header" style="
+                        display: flex; align-items: center; justify-content: space-between;
+                        padding: 0.6rem 0.75rem; cursor: pointer;
+                        background: var(--bg-secondary); border-radius: 12px;
+                        border: 1px solid var(--border-color);
+                    ">
+                        <span style="font-size: 0.875rem; font-weight: 700; color: var(--text-primary);">
+                            🩺 Squad Doctor
+                        </span>
+                        <i id="my-team-ai-chevron" class="fas fa-chevron-down" style="
+                            font-size: 0.7rem; color: var(--text-secondary);
+                            transition: transform 0.3s ease;
+                        "></i>
+                    </div>
+                    <div id="my-team-ai-insights-container" style="display: none; margin-top: 0.5rem;"></div>
+                </div>
                 ${bubbleFormationHTML}
                 ${renderCompactTeamList(allPlayers, gameweek, isLive)}
                 ${renderMatchSchedule(allPlayers, gameweek)}


### PR DESCRIPTION
…ompt

1. Collapse by default: Wrap insight banner in collapsible outer shell with chevron toggle. Content loads in background but stays hidden until user taps the "🩺 Squad Doctor" header bar.

2. Current GW tab: Add currentGWData (opponents, live points, isLive flag) to the context sent to Gemini. New 5th category "Current GW" adapts contextually — live GW shows performance review, pre-deadline shows opponent preview and bench suggestions.

3. Captain fix: Prompt now tells Gemini the captain is ALREADY LOCKED for the current GW. Captain Pick recommendations target next GW instead.