### PR TITLE
Fix live GW auto-refresh hijacking page when user navigates away

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -58,6 +58,11 @@ export async function navigate(page, subTab = 'overview') {
 
     console.log(`🧭 Navigating to: ${page}${subTab !== 'overview' ? `/${subTab}` : ''}`);
 
+    // Clean up team page resources (auto-refresh) when navigating away
+    if (page !== 'my-team') {
+        import('./renderMyTeam.js').then(m => m.cleanupTeamPage?.());
+    }
+
     currentPage = page;
     currentSubTab = subTab;
 

--- a/frontend/src/renderMyTeam.js
+++ b/frontend/src/renderMyTeam.js
@@ -226,6 +226,15 @@ function setupTeamAutoRefresh() {
 }
 
 /**
+ * Clean up team page resources when navigating away.
+ * Stops auto-refresh interval and resets state so it can restart on return.
+ */
+export function cleanupTeamPage() {
+    stopAutoRefresh();
+    myTeamState.autoRefreshStarted = false;
+}
+
+/**
  * Render My Team input form
  */
 export function renderMyTeamForm() {


### PR DESCRIPTION
Auto-refresh interval (every ~2 min during live GW) was never stopped when navigating away from the team page, causing renderMyTeam() to overwrite #app-container and yank the user back from leagues/stats/etc.

Add cleanupTeamPage() export that stops the interval and resets state, called from navigate() in main.js when the target page isn't my-team.