### PR TITLE
Add data freshness indicator + fix league chip tracker for mid-season…

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -38,6 +38,7 @@
                     <div id="gw-countdown" style="display: flex; align-items: center; gap: 0.5rem; padding: 0.5rem 0.9rem; background: rgba(255,255,255,0.1); border-radius: 0.5rem; font-size: 0.75rem;">
                         <i class="fas fa-clock"></i>
                         <span id="countdown-text">Loading...</span>
+                        <span id="data-freshness" style="opacity: 0.7; font-size: 0.65rem;"></span>
                     </div>
                 </div>
             </div>

--- a/frontend/src/aiManagerSnapshot.js
+++ b/frontend/src/aiManagerSnapshot.js
@@ -161,9 +161,14 @@ export function buildMyTeamInsightsContext(teamData) {
         }));
 
     // 3. Chips available (not yet used)
+    // All chips refresh mid-season, so each can be used up to 2 times total.
+    // A chip is available if it's been used fewer than 2 times.
     const usedChipNames = (managerSnapshot.chips.used || []).map(c => c.name);
     const allChips = ['wildcard', 'freehit', 'bboost', '3xc'];
-    const chipsAvailable = allChips.filter(c => !usedChipNames.includes(c));
+    const chipsAvailable = allChips.filter(c => {
+        const timesUsed = usedChipNames.filter(name => name === c).length;
+        return timesUsed < 2;
+    });
 
     // 4. Season trajectory (compact) from teamHistory
     let trajectory = null;

--- a/frontend/src/data.js
+++ b/frontend/src/data.js
@@ -174,6 +174,14 @@ export function getNextGameweek() {
 }
 
 /**
+ * Get timestamp of last successful data refresh
+ * @returns {number} Unix timestamp (ms) or 0 if never refreshed
+ */
+export function getLastRefreshTime() {
+    return lastRefreshTime;
+}
+
+/**
  * Get gameweek event data
  * @param {number} gameweek - Gameweek number
  * @returns {Object|null} Event object or null

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -246,7 +246,7 @@ function updateCountdown() {
     if (!countdownText) return;
 
     // Import from data.js module (use centralized GW functions)
-    import('./data.js').then(({ fplBootstrap, getActiveGW, getGameweekEvent, isGameweekLive }) => {
+    import('./data.js').then(({ fplBootstrap, getActiveGW, getGameweekEvent, isGameweekLive, getLastRefreshTime }) => {
         if (!fplBootstrap) {
             countdownText.textContent = 'Loading...';
             return;
@@ -300,6 +300,20 @@ function updateCountdown() {
         }
 
         countdownText.innerHTML = `<span style="color: ${urgencyColor}; font-size: 9px;">GW${gwNumber}: ${timeString}</span>`;
+
+        // Update data freshness indicator
+        const freshnessEl = document.getElementById('data-freshness');
+        if (freshnessEl) {
+            const lastRefresh = getLastRefreshTime();
+            if (!lastRefresh) {
+                freshnessEl.textContent = '';
+            } else {
+                const ageMins = Math.floor((Date.now() - lastRefresh) / 60000);
+                if (ageMins < 1) freshnessEl.textContent = '• Just now';
+                else if (ageMins < 60) freshnessEl.textContent = `• ${ageMins}m ago`;
+                else freshnessEl.textContent = `• ${Math.floor(ageMins / 60)}h ago`;
+            }
+        }
     });
 }
 

--- a/frontend/src/myTeam/leagueStandings.js
+++ b/frontend/src/myTeam/leagueStandings.js
@@ -454,35 +454,29 @@ export async function renderLeagueStandings(leagueData, myTeamState) {
     }
 
     // Helper function to get chips used abbreviations (excluding active chip)
+    // Returns HTML — bold abbreviation if a chip was used twice (mid-season refresh)
     function getChipsUsedAbbreviations(teamData) {
-        if (!teamData || !teamData.picks || !teamData.picks.chips) {
-            console.log('No chips data available:', teamData?.picks?.chips);
-            return '';
-        }
+        if (!teamData?.picks?.chips) return '';
 
-        console.log('Chips array:', teamData.picks.chips);
+        const chipMap = {
+            'freehit': 'FH', 'wildcard': 'WC',
+            'bboost': 'BB', 'benchboost': 'BB',
+            'triplecaptain': 'TC', '3xc': 'TC'
+        };
 
-        const chipsUsed = teamData.picks.chips
-            .filter(chip => {
-                const isPlayed = chip.event !== null && chip.event !== undefined;
-                console.log(`Chip ${chip.name}: event=${chip.event}, played=${isPlayed}`);
-                return isPlayed;
-            })
-            .map(chip => {
-                const chipMap = {
-                    'freehit': 'FH',
-                    'wildcard': 'WC',
-                    'bboost': 'BB',
-                    'benchboost': 'BB',
-                    'triplecaptain': 'TC',
-                    '3xc': 'TC'
-                };
-                return chipMap[chip.name] || '';
-            })
-            .filter(abbr => abbr !== '');
+        // Count how many times each chip abbreviation was used
+        const usedCounts = {};
+        teamData.picks.chips
+            .filter(chip => chip.event !== null && chip.event !== undefined)
+            .forEach(chip => {
+                const abbr = chipMap[chip.name] || '';
+                if (abbr) usedCounts[abbr] = (usedCounts[abbr] || 0) + 1;
+            });
 
-        console.log('Chips used abbreviations:', chipsUsed.join(' '));
-        return chipsUsed.join(' ');
+        // Build display: bold if used 2+ times (mid-season chip refresh)
+        return Object.entries(usedCounts)
+            .map(([abbr, count]) => count >= 2 ? `<b>${abbr}</b>` : abbr)
+            .join(' ');
     }
 
     // Helper function to count players played


### PR DESCRIPTION
… refresh

Data freshness: surfaces "• Xm ago" next to the GW countdown timer so the user can tell how stale the scores are during live GWs or after pull-to-refresh.

Chip tracker: deduplicates chips used twice (all chips refresh mid-season, not just WC) and bolds the abbreviation to signal double usage. Removes debug console.logs. Also fixes AI snapshot chipsAvailable logic to correctly treat a chip as available if used fewer than 2 times.